### PR TITLE
ci: update code

### DIFF
--- a/.github/workflows/Auto compile with openwrt sdk.yml
+++ b/.github/workflows/Auto compile with openwrt sdk.yml
@@ -129,10 +129,12 @@ jobs:
           fi
           cd sdk
 
-          cat << EOF >> feeds.conf.default
+          cat > feeds.tmp <<'EOF'
           src-git passwall_packages https://github.com/xiaorouji/openwrt-passwall-packages.git;main
           src-git passwall2 https://github.com/${{ env.passwall2 }}.git;${{ github.ref_name }}
           EOF
+          cat feeds.conf.default >> feeds.tmp
+          mv feeds.tmp feeds.conf.default
 
           
           ./scripts/feeds update -a
@@ -383,10 +385,12 @@ jobs:
       - name: ${{ matrix.platform }} feeds configuration packages
         run: |
           cd sdk
-          cat << EOF >> feeds.conf.default
+          cat > feeds.tmp <<'EOF'
           src-git passwall_packages https://github.com/xiaorouji/openwrt-passwall-packages.git;main
           src-git passwall2 https://github.com/${{ env.passwall2 }}.git;${{ github.ref_name }}
           EOF
+          cat feeds.conf.default >> feeds.tmp
+          mv feeds.tmp feeds.conf.default
 
 
           ./scripts/feeds update -a


### PR DESCRIPTION
1. Removed version 19.07
2. Now uses OpenWRT 24.01 and Snapshot SDK for compilation and packaging.
3. Packages include both IPK and APK files, along with all necessary dependencies.
4. Tested and passed.

https://github.com/xiaorouji/openwrt-passwall/discussions/4136