### PR TITLE
Fix interval to integer

### DIFF
--- a/luci-app-passwall2/luasrc/passwall2/util_xray.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_xray.lua
@@ -268,7 +268,7 @@ function gen_outbound(flag, node, tag, proxy_table)
 						port = string.gsub(node.hysteria2_hop, ":", "-"),
 						interval = (function()
 								local v = tonumber((node.hysteria2_hop_interval or "30s"):match("^%d+"))
-								return (v and v >= 5) and (v .. "s") or "30s"
+								return (v and v >= 5) and v or 30
 							    end)()
 					} or nil,
 					maxIdleTimeout = (function()


### PR DESCRIPTION
Xray 26.1.13 (Xray, Penetrates Everything.) OpenWrt (go1.25.5 linux/arm64) A unified platform for anti-censorship.
2026/01/18 17:13:53.373007 [Info] infra/conf/serial: Reading config: &{Name:/tmp/etc/passwall2/acl/default/global.json Format:json} Failed to start: main: failed to load config files: [/tmp/etc/passwall2/acl/default/global.json] > infra/conf/serial: failed to decode config: &{Name:/tmp/etc/passwall2/acl/default/global.json Format:json} > infra/conf/serial: failed to read config file at line 142 char 29 > json: cannot unmarshal string into Go struct field UdpHop.outbounds.streamSettings.hysteriaSettings.udphop.interval of type int64