### PR TITLE
Fix nil values in tonumber function

### DIFF
--- a/luci-app-passwall2/root/usr/share/passwall2/rule_update.lua
+++ b/luci-app-passwall2/root/usr/share/passwall2/rule_update.lua
@@ -60,7 +60,7 @@ end
 
 local function non_file_check(file_path, header_content)
 	local remote_file_size = nil
-	local local_file_size = tonumber(fs.stat(file_path, "size")) or 0
+	local local_file_size = tonumber(fs.stat(file_path, "size") or 0)
 	if local_file_size == 0 then
 		log(2, api.i18n.translate("Downloaded file is empty or an error occurred while reading it."))
 		return true


### PR DESCRIPTION
2026-01-22 15:47:39:   - /usr/share/passwall2/rule_update.lua:63: bad argument #1 to 'tonumber' (string expected, got nil)
2026-01-22 15:47:39:   - stack traceback:
	/usr/share/passwall2/rule_update.lua:188: in function </usr/share/passwall2/rule_update.lua:186>
	[C]: in function 'tonumber'
	/usr/share/passwall2/rule_update.lua:63: in function 'non_file_check'
	/usr/share/passwall2/rule_update.lua:123: in function 'fetch_geofile'
	/usr/share/passwall2/rule_update.lua:155: in function </usr/share/passwall2/rule_update.lua:154>
	[C]: in function 'xpcall'
	/usr/share/passwall2/rule_update.lua:186: in function 'safe_call'
	/usr/share/passwall2/rule_update.lua:195: in main chunk
	[C]: ?