### PR TITLE
Fix "sh: missing ]" while doing "/etc/init.d/passwall2 restart"

### DIFF
--- a/luci-app-passwall2/root/usr/share/passwall2/app.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/app.sh
@@ -170,7 +170,7 @@ run_xray() {
 				json_add_string "remote_dns_doh_port" "${_doh_port}"
 				json_add_string "remote_dns_doh_url" "${_doh_url}"
 				json_add_string "remote_dns_doh_host" "${_doh_host}"
-				[ -n "$_doh_bootstrap" ] json_add_string "remote_dns_doh_ip" "${_doh_bootstrap}"
+				[ -n "$_doh_bootstrap" ] && json_add_string "remote_dns_doh_ip" "${_doh_bootstrap}"
 			;;
 		esac
 		[ -n "$remote_dns_detour" ] && json_add_string "remote_dns_detour" "${remote_dns_detour}"


### PR DESCRIPTION
When we perform `opkg upgrade` or `/etc/init.d/passwall2 restart`, the system will throw an error prompt of `sh: missing]`.

```
+ json_add_string remote_dns_doh_host 1.1.1.1
+ local cur
+ _json_get_var cur JSON_CUR
+ eval 'cur="$JSON_CUR"'
+ cur=J_V
+ _json_add_generic string remote_dns_doh_host 1.1.1.1 J_V
+ local var
+ '[' J_V '=' J_A ]
+ var=remote_dns_doh_host
+ '[[' remote_dns_doh_host '==' remote_dns_doh_host ]]
+ export -- 'J_V_remote_dns_doh_host=1.1.1.1' 'T_J_V_remote_dns_doh_host=string'
+ _jshn_append JSON_UNSET J_V_remote_dns_doh_host
+ local '_a_value=J_V_remote_dns_doh_host'
+ eval 'JSON_UNSET="${JSON_UNSET} $_a_value"'
+ JSON_UNSET=' J_V_remote_dns_doh_port J_V_remote_dns_doh_url J_V_remote_dns_doh_host'
+ _jshn_append K_J_V remote_dns_doh_host
+ local '_a_value=remote_dns_doh_host'
+ eval 'K_J_V="${K_J_V} $_a_value"'
+ K_J_V=' remote_dns_doh_port remote_dns_doh_url remote_dns_doh_host'
+ '[' -n 1.1.1.1 ] json_add_string remote_dns_doh_ip 1.1.1.1
sh: missing ]
```
