### PR TITLE
Fix UI crash due to missing "Proxy" tab definition

### DIFF
--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/client/global.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/client/global.lua
@@ -318,13 +318,13 @@ if (mods:find("REDIRECT") and mods:find("TPROXY")) or (mods:find("nft_redir") an
 	o.rmempty = false
 else
 	local html = string.format([[<div class="cbi-checkbox"><input class="cbi-input-checkbox" type="checkbox" disabled></div><div class="cbi-value-description"><font color="red">%s</font></div>]], translate("Missing components, transparent proxy is unavailable."))
-	o = s:taboption("Proxy", DummyValue, "localhost_proxy", translate("Localhost Proxy"))
+	o = s:taboption("Main", DummyValue, "localhost_proxy", translate("Localhost Proxy"))
 	o.rawhtml = true
 	function o.cfgvalue(self, section)
 		return html
 	end
 
-	o = s:taboption("Proxy", DummyValue, "client_proxy", translate("Client Proxy"))
+	o = s:taboption("Main", DummyValue, "client_proxy", translate("Client Proxy"))
 	o.rawhtml = true
 	function o.cfgvalue(self, section)
 		return html


### PR DESCRIPTION
Fixed a runtime error where 'Proxy' tab was used without definition in the else block of global.lua.

In OpenWrt 25.12 , 24.10, luci-app-passwall2 26.1.19-r1, accessing the "Basic Settings" page triggers a Lua Runtime error:

Unhandled exception during request dispatching
/usr/lib/lua/luci/ucodebridge.lua:23: /usr/lib/lua/luci/cbi.lua:869: Cannot assign option to not existing tab "Proxy"

In previous versions, these "Localhost Proxy" and "Client Proxy" were displayed under the "Basic Setting->Main" tab. In the current client/global.lua, the code has been partially updated to use a new "Proxy" tab for new warning logic, but the mandatory s:tab("Proxy", ...) declaration is missing in the else branch of the component check. so It seems to be a minor logic oversight.
Actually, after further review, these options belong in the 'Main' tab as they did in previous versions. I've updated the code to redirect them back to the 'Main' tab instead of creating a new 'Proxy' tab. This keeps the UI consistent.

### Steps to reproduce this Bug

Install PassWall2 26.1.19-r1 in OpenWRT 24.10 or 25.12, where dependencies kmod-nft-tproxy is missing.

Open the PassWall2 Web Interface. See the LuCI "Unhandled exception" error page.
