### PR TITLE
Refactor command construction for geoview

### DIFF
--- a/luci-app-passwall2/luasrc/passwall2/util_sing-box.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_sing-box.lua
@@ -1,5 +1,6 @@
 module("luci.passwall2.util_sing-box", package.seeall)
 local api = require "luci.passwall2.api"
+local util = require "luci.util"
 local uci = api.uci
 local sys = api.sys
 local jsonc = api.jsonc
@@ -48,13 +49,14 @@ function geo_convert_srs(var)
 	local rule_name = var["rule_name"]
 	local output_srs_file = GEO_VAR.TO_SRS_PATH .. prefix .. "-" .. rule_name .. ".srs"
 	if not fs.access(output_srs_file) then
-		local cmd = string.format("geoview -type %s -action convert -input '%s' -list '%s' -output '%s' -lowmem=true",
-			prefix, geo_path, rule_name, output_srs_file)
+		local cmd = string.format("geoview -type %s -action convert -input %s -list %s -output %s -lowmem=true",
+			util.shellquote(prefix),
+			util.shellquote(geo_path),
+			util.shellquote(rule_name),
+			util.shellquote(output_srs_file)
+		)
 		sys.call(cmd)
-		local status = fs.access(output_srs_file) and "success." or "failed!"
-		if status == "failed!" then
-			api.log(0, string.format("  - %s:%s convert to srs %s", prefix, rule_name, status))
-		end
+		api.log(0, string.format("  - %s:%s convert to srs %s", prefix, rule_name, fs.access(output_srs_file) and "success." or "failed!"))
 	end
 end
 


### PR DESCRIPTION
防止命令注入应该对外部参数进行转义
