### PR TITLE
fix: hysteria2 native client "unsupported transport type"

### DIFF
--- a/luci-app-passwall2/luasrc/passwall2/util_hysteria2.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_hysteria2.lua
@@ -60,7 +60,7 @@ function gen_config(var)
 	local config = {
 		server = server,
 		transport = {
-			type = node.protocol or "udp",
+			type = "udp",
 			udp = {
 				hopInterval = (function()
 							local HopIntervalStr = tostring(node.hysteria2_hop_interval or "30s")


### PR DESCRIPTION
`util_hysteria2.lua` 第63行 `node.protocol` 返回 `"hysteria2"`，但 Hysteria2 客户端的 transport.type 只接受 `"udp"`。

启动报错：
```
FATAL failed to initialize client {"error": "invalid config: transport.type: unsupported transport type"}
```

修复：`type = node.protocol or "udp"` → `type = "udp"`

GL-MT6000, OpenWrt 24.10, hysteria 2.8.1 测试通过。

原生客户端支持更细粒度的 QUIC 窗口调优（initStreamReceiveWindow、maxConnReceiveWindow 等），这些参数在 Xray core 中不可配置。

---

Line 63: `node.protocol` = `"hysteria2"`, not a valid transport type. Native client expects `"udp"`.

Fix: `type = node.protocol or "udp"` → `type = "udp"`

Tested on GL-MT6000, OpenWrt 24.10, hysteria 2.8.1.

The native client also supports granular QUIC window tuning (initStreamReceiveWindow, maxConnReceiveWindow, etc.) not available in Xray core.