### PR TITLE
ci: enable RU i18n package in build

### DIFF
--- a/.github/workflows/Auto compile with openwrt sdk.yml
+++ b/.github/workflows/Auto compile with openwrt sdk.yml
@@ -188,6 +188,7 @@ jobs:
           echo "CONFIG_ALL_KMODS=n" >> .config
           echo "CONFIG_ALL=n" >> .config
           echo "CONFIG_AUTOREMOVE=n" >> .config
+          echo "CONFIG_LUCI_LANG_ru=y" >> .config
           echo "CONFIG_LUCI_LANG_zh_Hans=y" >> .config
           echo "CONFIG_LUCI_LANG_zh_Hant=y" >> .config
           echo "CONFIG_PACKAGE_luci-app-passwall2=m" >> .config


### PR DESCRIPTION
Added compilation of the RU localization package to CI. 
This is required to deliver updates to clients that are configured to receive release builds from the current repo.