### PR TITLE
fix(luci-app-passwall2): harden add-node and rule update actions

### DIFF
--- a/luci-app-passwall2/luasrc/controller/passwall2.lua
+++ b/luci-app-passwall2/luasrc/controller/passwall2.lua
@@ -603,7 +603,11 @@ function save_node_list_opt()
 end
 
 function update_rules()
-	local update = http.formvalue("update")
+	local update = http.formvalue("update") or ""
+	if update == "" then
+		http_write_json_error({ message = "missing update target" })
+		return
+	end
 	luci.sys.call("lua /usr/share/passwall2/rule_update.lua log '" .. update .. "' > /dev/null 2>&1 &")
 	http_write_json()
 end

--- a/luci-app-passwall2/luasrc/view/passwall2/node_list/node_list.htm
+++ b/luci-app-passwall2/luasrc/view/passwall2/node_list/node_list.htm
@@ -298,7 +298,7 @@ table td, .table .td {
 	function to_add_node() {
 		ajaxAbortAll();
 		const dom = document.getElementsByClassName("cbi-tab")[0];
-		const current_group = dom.getAttribute("group_name")
+		const current_group = dom ? (dom.getAttribute("group_name") || "default") : "default";
 		window.location.href='<%=api.url("add_node")%>?redirect=1&group=' + current_group;
 	}
 	


### PR DESCRIPTION
1. 当节点列表为空时，点击“添加”没有任何反应。
原因是 `to_add_node()` 默认假设页面中一定存在 `.cbi-tab[0]`，但在空节点列表场景下这个元素并不存在，前端脚本会直接报错。
修复方式：当没有分组 tab 时，默认回退到 `default` 分组。

2. `update_rules()` 在缺少 `update` 参数时会直接触发 500 错误。
原因是后端代码直接把 `nil` 拼接进 shell 命令，导致运行时异常。
修复方式：对空参数做保护，返回 JSON 错误，而不是抛出 500。