### PR TITLE
luci: Check kernel config for redirect, tproxy, ipv6 nat support

### DIFF
--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/client/global.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/client/global.lua
@@ -135,7 +135,22 @@ if handle then
 	handle:close()
 end
 
-if (mods:find("REDIRECT") and mods:find("TPROXY")) or (mods:find("nft_redir") and mods:find("nft_tproxy")) then
+local has_redir = mods:find("REDIRECT") or mods:find("nft_redir")
+local has_tproxy = mods:find("TPROXY") or mods:find("nft_tproxy")
+
+if not (has_redir and has_tproxy) then
+	local kconfig_handle = io.popen("zcat /proc/config.gz 2>/dev/null")
+	if kconfig_handle then
+		local kconfig = kconfig_handle:read("*a") or ""
+		kconfig_handle:close()
+		if kconfig ~= "" then
+			has_redir = has_redir or kconfig:find("CONFIG_NFT_REDIR=y")
+			has_tproxy = has_tproxy or kconfig:find("CONFIG_NFT_TPROXY=y")
+		end
+	end
+end
+
+if (has_redir and has_tproxy) then
 	o = s:taboption("Main", Flag, "localhost_proxy", translate("Localhost Proxy"), translate("When selected, localhost can transparent proxy."))
 	o.default = "1"
 	o.rmempty = false

--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/client/other.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/client/other.lua
@@ -114,7 +114,24 @@ if handle then
 	handle:close()
 end
 
-if (mods:find("REDIRECT") and mods:find("TPROXY")) or (mods:find("nft_redir") and mods:find("nft_tproxy")) then
+local has_redir = mods:find("REDIRECT") or mods:find("nft_redir")
+local has_tproxy = mods:find("TPROXY") or mods:find("nft_tproxy")
+local has_ip6t_mangle = mods:find("ip6table_mangle")
+
+if not (has_redir and has_tproxy and has_ip6t_mangle) then
+	local kconfig_handle = io.popen("zcat /proc/config.gz 2>/dev/null")
+	if kconfig_handle then
+		local kconfig = kconfig_handle:read("*a") or ""
+		kconfig_handle:close()
+		if kconfig ~= "" then
+			has_redir = has_redir or kconfig:find("CONFIG_NFT_REDIR=y")
+			has_tproxy = has_tproxy or kconfig:find("CONFIG_NFT_TPROXY=y")
+			has_ip6t_mangle = has_ip6t_mangle or kconfig:find("CONFIG_IP6_NF_MANGLE=y")
+		end
+	end
+end
+
+if (has_redir and has_tproxy) then
 	o = s:option(ListValue, "tcp_proxy_way", translate("TCP Proxy Way"))
 	o.default = "redirect"
 	o:value("redirect", "REDIRECT")
@@ -132,7 +149,7 @@ if (mods:find("REDIRECT") and mods:find("TPROXY")) or (mods:find("nft_redir") an
 		self.map:set(section, "tcp_proxy_way", value)
 	end
 
-	if mods:find("ip6table_mangle") or mods:find("nft_tproxy") then
+	if has_ip6t_mangle or has_tproxy then
 		---- IPv6 TProxy
 		o = s:option(Flag, "ipv6_tproxy", translate("IPv6 TProxy"),
 			"<font color='red'>" ..

--- a/luci-app-passwall2/root/usr/share/passwall2/iptables.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/iptables.sh
@@ -24,8 +24,15 @@ ipt_n="$ipt -t nat -w"
 ipt_m="$ipt -t mangle -w"
 ip6t_n="$ip6t -t nat -w"
 ip6t_m="$ip6t -t mangle -w"
-[ -z "$ip6t" -o -z "$(lsmod | grep 'ip6table_nat')" ] && ip6t_n="eval #$ip6t_n"
-[ -z "$ip6t" -o -z "$(lsmod | grep 'ip6table_mangle')" ] && ip6t_m="eval #$ip6t_m"
+KCONFIG=$(zcat /proc/config.gz 2>/dev/null)
+
+has_ip6t_nat=$(lsmod | grep 'ip6table_nat')
+[ -z "$has_ip6t_nat" ] && has_ip6t_nat=$(echo "$KCONFIG" | grep 'CONFIG_IP6_NF_NAT=y')
+[ -z "$ip6t" -o -z "$has_ip6t_nat" ] && ip6t_n="eval #$ip6t_n"
+
+has_ip6t_mangle=$(lsmod | grep 'ip6table_mangle')
+[ -z "$has_ip6t_mangle" ] && has_ip6t_mangle=$(echo "$KCONFIG" | grep 'CONFIG_IP6_NF_MANGLE=y')
+[ -z "$ip6t" -o -z "$has_ip6t_mangle" ] && ip6t_m="eval #$ip6t_m"
 FWI=$(uci -q get firewall.passwall2.path 2>/dev/null)
 FAKE_IP="198.18.0.0/16"
 FAKE_IP_6="fc00::/18"


### PR DESCRIPTION
Allows using passwall2 on kernels that have built-in support for these features.

Fixes #1110