### PR TITLE
luci-app-passwall2: fix port-collision bug in ACL rules

### DIFF
--- a/luci-app-passwall2/root/usr/share/passwall2/app.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/app.sh
@@ -1012,9 +1012,10 @@ acl_app() {
 	[ -n "$items" ] && {
 		local index=0
 		local item
-		local redir_port dns_port dnsmasq_port
+		local redir_port dns_port dnsmasq_port socks_port
 		local ipt_tmp msg msg2
 		redir_port=11200
+		socks_port=11600
 		dns_port=11300
 		dnsmasq_port=${GLOBAL_DNSMASQ_PORT:-11400}
 		for item in $items; do
@@ -1098,12 +1099,13 @@ acl_app() {
 							set_cache_var "ACL_${sid}_default" "1"
 						else
 							redir_port=$(get_new_port $(expr $redir_port + 1))
+							socks_port=$(get_new_port $(expr $socks_port + 1))
 
 							local type=$(echo $(config_n_get $node type) | tr 'A-Z' 'a-z')
 							if [ -n "${type}" ]; then
 								config_file=$TMP_ACL_PATH/${node}_TCP_UDP_DNS_${redir_port}.json
 								dns_port=$(get_new_port $(expr $dns_port + 1))
-								local acl_socks_port=$(get_new_port $(expr $redir_port + $index))
+								local acl_socks_port=$socks_port
 								local run_func
 								[ -n "${XRAY_BIN}" ] && run_func="run_xray"
 								[ -n "${SINGBOX_BIN}" ] && run_func="run_singbox"


### PR DESCRIPTION
### Description

**Bug:**
In `app.sh`, inside the `acl_app()` function, `redir_port` starts at `11200` and is incremented sequentially for each active rule. However, `acl_socks_port` is calculated as `redir_port + index` (where `index` is incremented for all rules, whether enabled or disabled).
If there are multiple active rules, or a mix of enabled/disabled rules, this causes the `acl_socks_port` of a prior rule to conflict with the `redir_port` of a subsequent rule.

**Case 1 (Consecutive enabled rules):**
- **Rule 1** (enabled): `redir_port` = 11201, `acl_socks_port` = 11202 (index = 1)
- **Rule 2** (enabled): `redir_port` = 11202, `acl_socks_port` = 11204 (index = 2)
Rule 1's socks port (`11202`) and Rule 2's redir port (`11202`) collide.

**Case 2 (With disabled rules in between):**
- **Rule 1** (enabled): `redir_port` = 11201, `acl_socks_port` = 11202 (index = 1)
- **Rule 2** (disabled): (index = 2, skipped, no ports allocated)
- **Rule 3** (enabled): `redir_port` = 11202, `acl_socks_port` = 11205 (index = 3)
Rule 1's socks port (`11202`) and Rule 3's redir port (`11202`) collide.

In both cases, port collisions cause the subsequent proxy backend process to crash or fail to bind on startup.

**Fix:**
We introduce a separate `socks_port` variable starting at `11600`, and increment it independently for each active rule. This completely separates the redir port and socks port ranges, preventing any port conflicts.

---

### 中文说明

**问题描述：**
在 `app.sh` 的 `acl_app()` 函数中，`redir_port` 从 `11200` 开始，并针对每个启用的规则依次递增。然而，Socks 端口 `acl_socks_port` 是通过 `redir_port + index` 计算的（其中 `index` 针对所有启用和禁用的规则都会递增）。
这导致当前驱规则的 Socks 端口与后继规则的 Redirection 端口发生重合冲突。

**场景 1（连续启用的规则）：**
- **规则 1**（启用）：`redir_port` = 11201，`acl_socks_port` = 11202 (index = 1)
- **规则 2**（启用）：`redir_port` = 11202，`acl_socks_port` = 11204 (index = 2)
规则 1 的 Socks 端口（11202）与规则 2 的 Redir 端口（11202）冲突。

**场景 2（中间夹杂禁用的规则）：**
- **规则 1**（启用）：`redir_port` = 11201，`acl_socks_port` = 11202 (index = 1)
- **规则 2**（禁用）：（index = 2，跳过，不分配端口）
- **规则 3**（启用）：`redir_port` = 11202，`acl_socks_port` = 11205 (index = 3)
规则 1 的 Socks 端口（11202）与规则 3 的 Redir 端口（11202）发生碰撞。

无论哪种情况，都会导致后续进程因端口被占用而启动失败。

**修复方案：**
引入了一个独立的 `socks_port` 变量（初始值 `11600`），并在循环处理启用的访问控制规则时单独递增分配。让 Redir 端口和 Socks 端口范围完全隔离，彻底避免冲突。