### PR TITLE
fix(sing-box): bypass private IP DNS resolution loop

### DIFF
--- a/luci-app-passwall2/luasrc/passwall2/util_sing-box.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_sing-box.lua
@@ -1797,6 +1797,12 @@ function gen_config(var)
 		end
 	end
 
+	table.insert(route.rules, {
+		action = "route",
+		ip_is_private = true,
+		outbound = "direct"
+	})
+
 	if COMMON.default_outbound_tag then
 		route.final = COMMON.default_outbound_tag
 	end


### PR DESCRIPTION
## English
IMPORTANT NOTE: This fix is specifically applied to the sing-box core configuration (`util_sing-box.lua`). Other core configurations (such as Xray) are not modified.

==================================================

### Description
This PR resolves an intermittent DNS resolution timeout/loop issue for clients using transparent proxy mode under certain configurations.

### Root Cause
When client UDP DNS traffic is intercepted by `TPROXY` and forwarded to the local `sing-box` instance, it is then redirected to the local dnsmasq port (e.g. `192.168.123.1:11404`) via `nat PREROUTING` rules. 
Because `sing-box` did not have a default rule to handle private IPs within its `route.rules` list, it detoured these local DNS query requests back to the remote outbound proxy. The remote proxy server dropped the private destination packets, causing DNS resolution loops and timeouts.

### Example (DNS Loop Sequence)
1. **Client PC** sends a DNS query to Gateway IP `192.168.123.1:53`.
2. **Firewall Mangle TPROXY** intercepts this UDP packet and redirects it to `sing-box` `tproxy_udp` inbound on port `11204`.
3. **Without the Fix**:
   - `sing-box` receives the packet with destination `192.168.123.1:53`.
   - None of the routing rules match `192.168.123.1`, so it falls back to `route.final` (e.g., `"default:US proxy"`).
   - `sing-box` attempts to send the packet to the remote proxy server. The remote server rejects or drops the private IP packet.
   - Result: **DNS Query Timeout / Latency Spike**.
4. **With the Fix**:
   - The packet matches the new rule `ip_is_private=true => route(direct)`.
   - `sing-box` routes the packet directly to local interface.
   - Result: **Instant DNS resolution**.

### Solution
In `util_sing-box.lua`, append a default rule to bypass private IP destinations directly:
```json
{
  "action": "route",
  "ip_is_private": true,
  "outbound": "direct"
}
```

--------------------------------------------------------------------------------------

## 中文
注意：此修复仅针对 sing-box 内核配置（修改了 `util_sing-box.lua`），Xray 等其他内核配置未作改动。

==================================================
### 问题简述
此 PR 修复了在某些配置下，透明代理模式的客户端出现间歇性 DNS 解析超时和解析环路的 bug。

### 根本原因
当客户端的 UDP 53 端口 DNS 请求被防火墙的 `TPROXY` 规则拦截并转发至本地的 `sing-box` 实例时，由于 `sing-box` 的 `route.rules` 路由规则中缺少任何局域网/私有 IP 绕过规则，这些发往网关本地的 DNS 查询请求（如发给本地 dnsmasq `192.168.123.1:11404` 的请求）会被错误地发送至远程代理服务器。远程代理服务器无法路由私有 IP，从而丢弃数据包导致 DNS 解析超时。

### 环路示例说明
1. **客户端 PC** 发送 DNS 请求到网关 IP `192.168.123.1:53`。
2. 防火墙 **Mangle TPROXY** 拦截该 UDP 包并重定向到 `sing-box` 的 `tproxy_udp` 端口 `11204`。
3. **修复前**：
   - `sing-box` 收到目的地址为 `192.168.123.1:53` 的数据包。
   - 路由规则中无匹配项，回退到默认出站 `route.final`（即远程代理节点）。
   - 数据包被发送到国外代理服务器，随后被丢弃。
   - **结果：DNS 解析超时与卡顿**。
4. **修复后**：
   - 数据包匹配新增的路由规则 `ip_is_private = true`。
   - `sing-box` 直接将其路由到直连出站 (`direct`)，返回网关本地解析。
   - **结果：DNS 瞬间秒开**。

### 解决方案
在 `util_sing-box.lua` 中生成配置时，于 `route.rules` 末尾追加一条默认的直连私有 IP 规则：
```json
{
  "action": "route",
  "ip_is_private": true,
  "outbound": "direct"
}
```