### PR TITLE
Fix the problem of service startup stuck during apk upgrade

### DIFF
--- a/luci-app-passwall2/root/usr/share/passwall2/app.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/app.sh
@@ -1149,8 +1149,9 @@ acl_app() {
 
 start() {
 	busybox pgrep -f /tmp/etc/passwall2/bin > /dev/null 2>&1 && {
-		#log_i18n 0 "The program has started. Please stop it and then restart it!"
-		stop
+		logger -t PW2-RESTART "Upgrade or overload residue is detected, and the subprocess is being called to perform complete cleaning..."
+		(stop)
+		sleep 2
 	}
 	mkdir -p /tmp/etc /tmp/log $TMP_PATH $TMP_BIN_PATH $TMP_SCRIPT_FUNC_PATH $TMP_ROUTE_PATH $TMP_ACL_PATH $TMP_PATH2
 	get_config


### PR DESCRIPTION
- Add a system log for troubleshooting
- Modify `stop` to `(stop)` so that it executes `exit 0` in the sub-process, which will not cause the main process to exit early.
- Add sleep 2 to completely free up port and memory space on the kernel.

To fix https://github.com/Openwrt-Passwall/openwrt-passwall2/issues/1116