### PR TITLE
luci: 保留 AnyTLS Clash 订阅中的 Reality 参数

### DIFF
--- a/luci-app-passwall2/root/usr/share/passwall2/subscribe.lua
+++ b/luci-app-passwall2/root/usr/share/passwall2/subscribe.lua
@@ -759,6 +759,15 @@ local function parseClashNode(node, add_mode, group, sub_cfg)
 		if sub_allowinsecure then
 			result.tls_allowInsecure = "1"
 		end
+		if node["client-fingerprint"] then
+			result.utls = "1"
+			result.fingerprint = node["client-fingerprint"]
+		end
+		if node.tls and node["reality-opts"] and node["reality-opts"]["public-key"] then
+			result.reality = "1"
+			result.reality_publicKey = node["reality-opts"]["public-key"]
+			result.reality_shortId = node["reality-opts"]["short-id"]
+		end
 	end
 	if not result.remarks or result.remarks == "" then
 		if result.address and result.port then


### PR DESCRIPTION
## 问题

当导入 Clash YAML 格式的 AnyTLS 节点时，如果节点使用 Reality，例如包含：

```yaml
reality-opts:
  public-key: ...
  short-id: ...
client-fingerprint: random
```

PassWall2 当前只会导入 AnyTLS 的基础字段，未保留 `reality-opts` 和 `client-fingerprint`。后续生成 sing-box 配置时缺少 Reality 所需的 `public_key`/`short_id` 和 uTLS 指纹，导致节点可以被导入，但实际连接失败。

## 修复

在 Clash 订阅解析的 AnyTLS 分支中补充：

- `client-fingerprint` -> `utls` / `fingerprint`
- `reality-opts.public-key` -> `reality_publicKey`
- `reality-opts.short-id` -> `reality_shortId`
- 设置 `reality = "1"`

实现方式与现有 VLESS Reality 字段映射保持一致。

## 验证

已执行：

```bash
python3 /tmp/pw2fix/check_anytls_reality.py
lua -e "assert(loadfile('luci-app-passwall2/root/usr/share/passwall2/subscribe.lua'))"
git diff --check HEAD~1..HEAD
```

并在 OpenWrt 环境中验证过：补齐 Reality 字段后，AnyTLS 节点可以通过 sing-box SOCKS 成功访问目标站点。
