### PR TITLE
Restart service after saving LuCI config

### DIFF
--- a/luci-app-passwall2/luasrc/passwall2/api.lua
+++ b/luci-app-passwall2/luasrc/passwall2/api.lua
@@ -1361,6 +1361,7 @@ function set_apply_on_parse(map)
 			map.on_after_save = function(self)
 				if old then old(self) end
 				map:set("@global[0]", "timestamp", os.time())
+				sys.call("/etc/init.d/passwall2 restart >/dev/null 2>&1 &")
 			end
 			local cbi = require "luci.cbi"
 			map:append(cbi.Template(appname .. "/cbi/optimize_cbi_ui"))


### PR DESCRIPTION
## Summary
- restart passwall2 after LuCI CBI config pages save changes
- keep the existing timestamp update behavior in set_apply_on_parse
- cover pages that share api.set_apply_on_parse, including global settings and node config

## Verification
- inspected the shared set_apply_on_parse lifecycle used by node_config.lua and other CBI pages
- local Lua runtime was unavailable in this environment