### PR TITLE
fix: auto-migrate fragment configs and prevent xray core panic

### DIFF
--- a/luci-app-passwall2/luasrc/passwall2/util_xray.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_xray.lua
@@ -923,7 +923,7 @@ function gen_config(var)
 			type = "fragment",
 			settings = {
 				packets = xray_settings.fragment_packets,
-				lengths = #lengths > 0 and lengths or nil,
+				lengths = #lengths > 0 and lengths or {"100-200"},
 				delays = #delays > 0 and delays or nil,
 				maxSplit = xray_settings.fragment_maxSplit
 			}

--- a/luci-app-passwall2/root/etc/uci-defaults/luci-passwall2
+++ b/luci-app-passwall2/root/etc/uci-defaults/luci-passwall2
@@ -49,6 +49,10 @@ chmod +x /usr/share/passwall2/*.sh
 [ "$(uci -q get passwall2.@global_xray[0].sniffing)" == "1" ] && [ "$(uci -q get passwall2.@global_xray[0].route_only)" != "1" ] && uci -q set passwall2.@global_xray[0].sniffing_override_dest=1
 uci -q delete passwall2.@global_xray[0].sniffing
 uci -q delete passwall2.@global_xray[0].route_only
+frag_len=$(uci -q get passwall2.@global_xray[0].fragment_length)
+[ -n "$frag_len" ] && uci -q set passwall2.@global_xray[0].fragment_lengths="$frag_len" && uci -q delete passwall2.@global_xray[0].fragment_length
+frag_dly=$(uci -q get passwall2.@global_xray[0].fragment_delay)
+[ -n "$frag_dly" ] && uci -q set passwall2.@global_xray[0].fragment_delays="$frag_dly" && uci -q delete passwall2.@global_xray[0].fragment_delay
 uci -q commit passwall2
 
 sed -i "s#add_from#group#g" /etc/config/passwall2 2>/dev/null


### PR DESCRIPTION
This PR fixes a critical issue introduced in commit [fe7974e](https://github.com/Openwrt-Passwall/openwrt-passwall2/commit/fe7974e7d26a58c46443ea322d3940135b2d3a6f) where users upgrading from older versions experience an Xray infinite restart loop. 

Related issue：https://github.com/Openwrt-Passwall/openwrt-passwall2/issues/1181


To resolve this elegantly, this PR introduces the fixes:

**Data Migration (`etc/uci-defaults/luci-passwall2`)**
   - Added a silent auto-migration script block. It automatically detects and renames legacy `fragment_length` and `fragment_delay` to their new plural counterparts.
   - This ensures LuCI UI consistency for upgrading users and cleans up orphaned UCI data.

   - This guarantees Xray always receives a valid JSON structure, completely eliminating the `min can't be 0` panic.

### ✅ Testing
- [x] Tested upgrade path from older configs (verified UCI auto-migration).
- [x] Tested with empty inputs and malformed strings (verified Lua fallback works).
- [x] Verified Xray starts successfully without fragment errors.