### PR TITLE
fix trojan ech parse

### DIFF
--- a/luci-app-passwall2/luasrc/view/passwall2/node_config/link_share_man.htm
+++ b/luci-app-passwall2/luasrc/view/passwall2/node_config/link_share_man.htm
@@ -1314,6 +1314,8 @@ local current_node = map:get(section)
 						opt.set(dom_prefix + 'utls', true);
 						opt.set(dom_prefix + 'fingerprint', queryParam.fp);
 					}
+					opt.set(dom_prefix + 'ech', !!queryParam.ech);
+					opt.set(dom_prefix + 'ech_config', queryParam.ech || '');
 					opt.set(dom_prefix + 'tls_pinSHA256', queryParam.pcs || '');
 					opt.set(dom_prefix + 'tls_CertByName', queryParam.vcn || '');
 					opt.set(

--- a/luci-app-passwall2/root/usr/share/passwall2/subscribe.lua
+++ b/luci-app-passwall2/root/usr/share/passwall2/subscribe.lua
@@ -1368,6 +1368,10 @@ local function processData(szType, content, add_mode, group, sub_cfg)
 					result.reality_publicKey = params.pbk or nil
 					result.reality_shortId = params.sid or nil
 				end
+				if params.ech and params.ech ~= "" then
+					result.ech = "1"
+					result.ech_config = params.ech
+				end
 				result.tls_pinSHA256 = params.pcs
 				result.tls_CertByName = params.vcn
 				local insecure = params.allowinsecure or params.allowInsecure or params.insecure


### PR DESCRIPTION
Add parsing logic for the ECH parameter in the trojan branch of subscribe.lua and link_share_man.htm to align with the VLESS branch; local verification passed

在 subscribe.lua 与 link_share_man.htm 的 trojan 分支中新增 ECH 参数解析逻辑，与 VLESS 分支实现对齐，本地验证通过