### PR TITLE
fix(acl): respect 'direct' flag in access control rules

### DIFF
--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/client/global.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/client/global.lua
@@ -175,7 +175,7 @@ o.description = "<br /><ul>"
 .. "<li>" .. translate("Subdomain (recommended): Begining with 'domain:' and the rest is a domain. When the targeting domain is exactly the value, or is a subdomain of the value, this rule takes effect. Example: rule 'domain:v2ray.com' matches 'www.v2ray.com', 'v2ray.com', but not 'xv2ray.com'.") .. "</li>"
 .. "<li>" .. translate("Full domain: Begining with 'full:' and the rest is a domain. When the targeting domain is exactly the value, the rule takes effect. Example: rule 'domain:v2ray.com' matches 'v2ray.com', but not 'www.v2ray.com'.") .. "</li>"
 .. "<li>" .. translate("Such as:") .. "</li>"
-.. "<li>" .. "domain:my-nodes.com tcp://223.5.5.5" .. "</li>"
+.. "<li>" .. "domain:my-nodes.com tcp://119.29.29.29" .. "</li>"
 .. "<li>" .. "domain:vpn.com udp://119.29.29.29:53" .. "</li>"
 .. "<li>" .. "full:www.dnspod.com https://120.53.53.53/dns-query" .. "</li>"
 .. "<li>" .. '<a style="color:red">' .. translate("Please note that the program will not start if the format is incorrect!") .. '</a>' .. "</li>"
@@ -188,6 +188,12 @@ o.default = "UseIP"
 o:value("UseIP")
 o:value("UseIPv4")
 o:value("UseIPv6")
+
+if current_node.type == "sing-box" then
+	o = s:taboption("DNS", Value, "direct_dns", translate("Direct DNS"), translate("Optional. Leave empty to use the WAN DNS. Supports udp://IP:PORT, tcp://IP:PORT, or https://HOST/dns-query,BOOTSTRAP_IP. Direct DNS bypasses the transparent proxy."))
+	o:value("https://120.53.53.53/dns-query", "DNSPod DoH")
+	o:value("udp://119.29.29.29:53", "DNSPod UDP")
+end
 
 o = s:taboption("DNS", ListValue, "remote_dns_protocol", translate("Remote DNS Protocol"))
 o:value("tcp", "TCP")

--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/client/node_subscribe_config.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/client/node_subscribe_config.lua
@@ -135,14 +135,12 @@ o:value("https", "DoH")
 o = s:option(Value, "domain_resolver_dns", "DNS")
 o.datatype = "or(ipaddr,ipaddrport)"
 o:value("114.114.114.114")
-o:value("223.5.5.5:53")
 o.default = o.keylist[1]
 o:depends({ domain_resolver = "tcp" })
 o:depends({ domain_resolver = "udp" })
 
 o = s:option(Value, "domain_resolver_dns_https", "DNS")
 o:value("https://120.53.53.53/dns-query", "DNSPod")
-o:value("https://223.5.5.5/dns-query", "AliDNS")
 o.default = o.keylist[1]
 o:depends({ domain_resolver = "https" })
 

--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/client/type/ray.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/client/type/ray.lua
@@ -786,14 +786,12 @@ o:value("https", "HTTPS")
 o = s:option(Value, _n("domain_resolver_dns"), "DNS")
 o.datatype = "or(ipaddr,ipaddrport)"
 o:value("114.114.114.114")
-o:value("223.5.5.5:53")
 o.default = o.keylist[1]
 o:depends({ [_n("domain_resolver")] = "tcp" })
 o:depends({ [_n("domain_resolver")] = "udp" })
 
 o = s:option(Value, _n("domain_resolver_dns_https"), "DNS")
 o:value("https://120.53.53.53/dns-query", "DNSPod")
-o:value("https://223.5.5.5/dns-query", "AliDNS")
 o.default = o.keylist[1]
 o:depends({ [_n("domain_resolver")] = "https" })
 

--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/client/type/sing-box.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/client/type/sing-box.lua
@@ -866,14 +866,12 @@ o:value("https", "HTTPS")
 o = s:option(Value, _n("domain_resolver_dns"), "DNS")
 o.datatype = "or(ipaddr,ipaddrport)"
 o:value("114.114.114.114")
-o:value("223.5.5.5:53")
 o.default = o.keylist[1]
 o:depends({ [_n("domain_resolver")] = "tcp" })
 o:depends({ [_n("domain_resolver")] = "udp" })
 
 o = s:option(Value, _n("domain_resolver_dns_https"), "DNS")
 o:value("https://120.53.53.53/dns-query", "DNSPod")
-o:value("https://223.5.5.5/dns-query", "AliDNS")
 o.default = o.keylist[1]
 o:depends({ [_n("domain_resolver")] = "https" })
 

--- a/luci-app-passwall2/luasrc/passwall2/api.lua
+++ b/luci-app-passwall2/luasrc/passwall2/api.lua
@@ -182,7 +182,7 @@ end
 
 -- Domain resolution
 function domainToIPv4(domain, dns)
-	local Dns = dns or "223.5.5.5"
+	local Dns = dns or "119.29.29.29"
 	local IPs = luci.sys.exec('nslookup %s %s | awk \'/^Name:/{getline; if ($1 == "Address:") print $2}\'' % { domain, Dns })
 	for IP in string.gmatch(IPs, "%S+") do
 		if datatypes.ipaddr(IP) and not datatypes.ip6addr(IP) then return IP end

--- a/luci-app-passwall2/luasrc/passwall2/util_sing-box.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_sing-box.lua
@@ -1117,6 +1117,7 @@ function gen_config(var)
 	local local_http_username = var["local_http_username"]
 	local local_http_password = var["local_http_password"]
 	local dns_listen_port = var["dns_listen_port"]
+	local direct_dns = var["direct_dns"]
 	local direct_dns_udp_server = var["direct_dns_udp_server"]
 	local direct_dns_udp_port = var["direct_dns_udp_port"]
 	local direct_dns_query_strategy = var["direct_dns_query_strategy"]
@@ -1825,18 +1826,39 @@ function gen_config(var)
 		tag = "local"
 	})
 
-	route.default_domain_resolver = {
-		server = "local"
-	}
-
-	if direct_dns_udp_server then
-		table.insert(dns.servers, {
-			tag = "direct",
+	local direct_dns_server
+	if direct_dns and direct_dns ~= "" then
+		local direct_dns_url, direct_dns_bootstrap = direct_dns:match("^([^,]+),?(.*)$")
+		direct_dns_server = parseDNS(direct_dns_url)
+		if direct_dns_server and direct_dns_bootstrap ~= "" and not api.is_ip(direct_dns_server.server) then
+			table.insert(dns.servers, {
+				tag = "direct-bootstrap",
+				type = "hosts",
+				predefined = {
+					[direct_dns_server.server] = direct_dns_bootstrap
+				}
+			})
+			direct_dns_server.domain_resolver = "direct-bootstrap"
+		end
+	end
+	if not direct_dns_server and direct_dns_udp_server then
+		direct_dns_server = {
 			type = "udp",
 			server = direct_dns_udp_server,
 			server_port = tonumber(direct_dns_udp_port) or 53,
-			detour = "direct",
-		})
+		}
+	end
+	if direct_dns_server then
+		direct_dns_server.tag = "direct"
+		direct_dns_server.detour = "direct"
+		table.insert(dns.servers, direct_dns_server)
+		route.default_domain_resolver = {
+			server = "direct"
+		}
+	else
+		route.default_domain_resolver = {
+			server = "local"
+		}
 	end
 
 	for i, v in pairs(GLOBAL.DNS_SERVER) do
@@ -2134,17 +2156,12 @@ function gen_config(var)
 	end
 
 	if next(ech_domain) ~= nil then
-		table.insert(dns.servers, {
-			tag = "ech-dns",
-			type = "https",
-			server = "223.5.5.5"
-		})
 		if not dns.rules then dns.rules = {} end
 		local domain = {}
 		for line, _ in pairs(ech_domain) do domain[#domain+1] = line end
 		table.insert(dns.rules, 1, {
 			domain = domain,
-			server = "ech-dns"
+			server = direct_dns_server and "direct" or "local"
 		})
 	end
 

--- a/luci-app-passwall2/root/usr/share/passwall2/app.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/app.sh
@@ -1293,9 +1293,6 @@ get_config() {
 		[ -n "$NODE" ] && [ "$(config_get_type $NODE)" == "nodes" ] && ENABLED_DEFAULT_ACL=1
 	}
 	ENABLED_ACLS=$(config_t_get global acl_enable 0)
-	[ "$ENABLED_ACLS" == 1 ] && {
-		[ "$(uci show ${CONFIG} | grep "@acl_rule" | grep "enabled='1'" | wc -l)" == 0 ] && ENABLED_ACLS=0
-	}
 	SOCKS_ENABLED=$(config_t_get global socks_enabled 0)
 	REDIR_PORT=$(echo $(get_new_port 1041 tcp,udp))
 	TCP_PROXY_WAY=$(config_t_get global_forwarding tcp_proxy_way redirect)

--- a/luci-app-passwall2/root/usr/share/passwall2/app.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/app.sh
@@ -201,9 +201,10 @@ run_xray() {
 
 run_singbox() {
 	local flag node redir_port tcp_proxy_way socks_address socks_port socks_username socks_password http_address http_port http_username http_password
-	local dns_listen_port direct_dns_query_strategy remote_dns_protocol remote_dns_udp_server remote_dns_tcp_server remote_dns_doh remote_dns_client_ip remote_dns_detour remote_fakedns remote_dns_query_strategy dns_cache
+	local dns_listen_port direct_dns direct_dns_query_strategy remote_dns_protocol remote_dns_udp_server remote_dns_tcp_server remote_dns_doh remote_dns_client_ip remote_dns_detour remote_fakedns remote_dns_query_strategy dns_cache
 	local loglevel log_file config_file
 	eval_set_val $@
+	[ -n "$direct_dns" ] || direct_dns="${DIRECT_DNS}"
 	local type=$(echo $(config_n_get $node type) | tr 'A-Z' 'a-z')
 	[ -z "$type" ] && return 1
 	node_protocol=$(config_n_get $node protocol)
@@ -321,6 +322,7 @@ run_singbox() {
 	}
 	json_add_string "direct_dns_udp_port" "${DIRECT_DNS_UDP_PORT}"
 	json_add_string "direct_dns_udp_server" "${DIRECT_DNS_UDP_SERVER}"
+	[ -n "$direct_dns" ] && json_add_string "direct_dns" "${direct_dns}"
 	json_add_string "direct_dns_query_strategy" "${direct_dns_query_strategy}"
 
 	[ -n "${redir_port}" ] && {
@@ -743,7 +745,11 @@ run_global_dnsmasq() {
 	else
 		#Run a copy dnsmasq instance, DNS hijack for that need proxy devices.
 		GLOBAL_DNSMASQ_PORT=$(get_new_port 11400)
-		run_copy_dnsmasq flag="default" listen_port=$GLOBAL_DNSMASQ_PORT local_dns="${DNSMASQ_LOCAL_DNS}" tun_dns="${DNSMASQ_TUN_DNS}" default_dns="${DNSMASQ_DEFAULT_DNS}"
+		if ! run_copy_dnsmasq flag="default" listen_port=$GLOBAL_DNSMASQ_PORT local_dns="${DNSMASQ_LOCAL_DNS}" tun_dns="${DNSMASQ_TUN_DNS}" default_dns="${DNSMASQ_DEFAULT_DNS}"; then
+			log_i18n 2 "Failed to start the dedicated DNS service on port %s." "${GLOBAL_DNSMASQ_PORT}"
+			unset GLOBAL_DNSMASQ_PORT
+			return 1
+		fi
 		DNS_REDIRECT_PORT=${GLOBAL_DNSMASQ_PORT}
 		#dhcp.leases to hosts
 		$APP_PATH/lease2hosts.sh > /dev/null 2>&1 &
@@ -945,7 +951,27 @@ run_copy_dnsmasq() {
 	json_add_string "NO_LOGIC_LOG" "${NO_LOGIC_LOG:-0}"
 	lua $APP_PATH/helper_dnsmasq.lua add_rule "$(json_dump)"
 
-	ln_run 0 "$(first_type dnsmasq)" "dnsmasq_${flag}" "/dev/null" -C $dnsmasq_conf -x $TMP_ACL_PATH/$flag/dnsmasq.pid
+	local dnsmasq_bin=$(first_type dnsmasq)
+	local dnsmasq_pid=$TMP_ACL_PATH/$flag/dnsmasq.pid
+	[ -n "$dnsmasq_bin" ] || {
+		log_i18n 2 "DNS service binary not found."
+		return 1
+	}
+	"$dnsmasq_bin" --test -C "$dnsmasq_conf" > /dev/null 2>&1 || {
+		log_i18n 2 "DNS service configuration validation failed: %s" "$dnsmasq_conf"
+		return 1
+	}
+	ln_run 0 "$dnsmasq_bin" "dnsmasq_${flag}" "/dev/null" -C $dnsmasq_conf -x $dnsmasq_pid
+	local retry=0
+	while [ "$retry" -lt 10 ]; do
+		[ -s "$dnsmasq_pid" ] && kill -0 "$(cat "$dnsmasq_pid")" 2>/dev/null && break
+		sleep 1
+		retry=$((retry + 1))
+	done
+	[ -s "$dnsmasq_pid" ] && kill -0 "$(cat "$dnsmasq_pid")" 2>/dev/null || {
+		log_i18n 2 "DNS service failed to listen on port %s." "$listen_port"
+		return 1
+	}
 	set_cache_var "ACL_${flag}_dns_port" "${listen_port}"
 }
 
@@ -1131,7 +1157,10 @@ acl_app() {
 								fi
 							fi
 							dnsmasq_port=$(get_new_port $(expr $dnsmasq_port + 1))
-							run_copy_dnsmasq flag="$sid" listen_port=$dnsmasq_port local_dns="${LOCAL_DNS:-${AUTO_DNS}}" tun_dns="127.0.0.1#${dns_port}" default_dns="${AUTO_DNS}"
+							if ! run_copy_dnsmasq flag="$sid" listen_port=$dnsmasq_port local_dns="${LOCAL_DNS:-${AUTO_DNS}}" tun_dns="127.0.0.1#${dns_port}" default_dns="${AUTO_DNS}"; then
+								log_i18n 2 "[%s] dedicated DNS service failed, skip this transparent proxy!" "${remarks}"
+								continue
+							fi
 							#dhcp.leases to hostsMore actions
 							$APP_PATH/lease2hosts.sh > /dev/null 2>&1 &
 
@@ -1311,6 +1340,7 @@ get_config() {
 	REMOTE_DNS=$(config_t_get global remote_dns 1.1.1.1:53 | sed 's/#/:/g' | sed -E 's/\:([^:]+)$/#\1/g')
 	REMOTE_FAKEDNS=$(config_t_get global remote_fakedns '0')
 	REMOTE_DNS_QUERY_STRATEGY=$(config_t_get global remote_dns_query_strategy UseIPv4)
+	DIRECT_DNS=$(config_t_get global direct_dns)
 	DNS_CACHE=$(config_t_get global dns_cache 1)
 	DNS_REDIRECT=$(config_t_get global dns_redirect 1)
 

--- a/luci-app-passwall2/root/usr/share/passwall2/nftables.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/nftables.sh
@@ -297,8 +297,8 @@ load_acl() {
 
 			tcp_no_redir_ports=${tcp_no_redir_ports:-default}
 			udp_no_redir_ports=${udp_no_redir_ports:-default}
-			tcp_proxy_mode="global"
-			udp_proxy_mode="global"
+			[ "$direct" = "1" ] && tcp_proxy_mode="disable" || tcp_proxy_mode="global"
+			[ "$direct" = "1" ] && udp_proxy_mode="disable" || udp_proxy_mode="global"
 			tcp_redir_ports=${tcp_redir_ports:-default}
 			udp_redir_ports=${udp_redir_ports:-default}
 			node=${node:-default}

--- a/luci-app-passwall2/root/usr/share/passwall2/socks_auto_switch.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/socks_auto_switch.sh
@@ -41,7 +41,7 @@ test_proxy() {
 			result=1
 		else
 			result=2
-			ping -c 3 -W 1 223.5.5.5 > /dev/null 2>&1
+			ping -c 3 -W 1 119.29.29.29 > /dev/null 2>&1
 			[ $? -eq 0 ] && {
 				result=1
 			}

--- a/luci-app-passwall2/root/usr/share/passwall2/test.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/test.sh
@@ -32,7 +32,7 @@ test_proxy() {
 			result=1
 		else
 			result=2
-			ping -c 3 -W 1 223.5.5.5 > /dev/null 2>&1
+			ping -c 3 -W 1 119.29.29.29 > /dev/null 2>&1
 			[ $? -eq 0 ] && {
 				result=1
 			}


### PR DESCRIPTION
Two fixes for ACL source-based bypass not working when `direct=1` is set:

**1. app.sh — incorrect ENABLED_ACLS detection**  
The check `grep "@acl_rule"` never matched because `uci show` outputs `name=acl_rule`, not `name=@acl_rule`. This caused `ENABLED_ACLS` to always be 0, so `load_acl` was never called.  
*Removed the broken check entirely — `acl_app()` already skips disabled rules internally.*

**2. nftables.sh — direct flag ignored**  
`tcp_proxy_mode` and `udp_proxy_mode` were hardcoded to `"global"` after eval, overriding the `direct` option from ACL config.  
*Changed to check `$direct` before setting proxy mode: `direct=1` → `disable` (bypass), otherwise `global` (respect global proxy).*