### PR TITLE
luci-app-passwall2: add independent log and loglevel support for ACL rules

### DIFF
--- a/luci-app-passwall2/luasrc/controller/passwall2.lua
+++ b/luci-app-passwall2/luasrc/controller/passwall2.lua
@@ -70,6 +70,7 @@ function index()
 	entry({"admin", "services", appname, "get_now_use_node"}, call("get_now_use_node")).leaf = true
 	entry({"admin", "services", appname, "get_redir_log"}, call("get_redir_log")).leaf = true
 	entry({"admin", "services", appname, "get_socks_log"}, call("get_socks_log")).leaf = true
+	entry({"admin", "services", appname, "get_acl_log"}, call("get_acl_log")).leaf = true
 	entry({"admin", "services", appname, "get_log"}, call("get_log")).leaf = true
 	entry({"admin", "services", appname, "clear_log"}, call("clear_log")).leaf = true
 	entry({"admin", "services", appname, "index_status"}, call("index_status")).leaf = true
@@ -259,6 +260,18 @@ function get_socks_log()
 	local path = "/tmp/etc/passwall2/SOCKS_" .. name .. ".log"
 	if nixio.fs.access(path) then
 		local content = luci.sys.exec("tail -n 5000 ".. path)
+		content = content:gsub("\n", "<br />")
+		http.write(content)
+	else
+		http.write(string.format("<script>alert('%s');window.close();</script>", i18n.translate("Not enabled log")))
+	end
+end
+
+function get_acl_log()
+	local id = http.formvalue("id")
+	local path = "/tmp/log/passwall2_acl_" .. id .. ".log"
+	if nixio.fs.access(path) then
+		local content = luci.sys.exec("tail -n 5000 '" .. path .. "'")
 		content = content:gsub("\n", "<br />")
 		http.write(content)
 	else

--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/client/acl_config.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/client/acl_config.lua
@@ -78,6 +78,33 @@ o = s:option(Value, "remarks", translate("Remarks"))
 o.default = arg[1]
 o.rmempty = false
 
+---- Log
+o = s:option(Flag, "log", translate("Enable Log"))
+o.default = 0
+o.rmempty = false
+
+o = s:option(ListValue, "loglevel", translate("Log Level"))
+o.default = "warn"
+o:value("debug", "Debug")
+o:value("info", "Info")
+o:value("warn", "Warning")
+o:value("error", "Error")
+o:depends("log", "1")
+
+o = s:option(DummyValue, "_acl_log", translate("Log File"))
+o.rawhtml = true
+o.cfgvalue = function(t, n)
+	local log_path = "/tmp/log/passwall2_acl_" .. arg[1] .. ".log"
+	local log_url = api.url("get_acl_log") .. "?id=" .. arg[1]
+	return string.format(
+		'<code>%s</code>&nbsp;&nbsp;<input class="btn cbi-button cbi-button-apply" type="button" value="%s" onclick="window.open(\'%s\', \'_blank\')" />',
+		log_path,
+		translate("View Log"),
+		log_url
+	)
+end
+o:depends("log", "1")
+
 o = s:option(Value, "interface", translate("Source Interface"))
 o:value("", translate("All"))
 local iface = api.get_network_devices()

--- a/luci-app-passwall2/root/usr/share/passwall2/app.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/app.sh
@@ -1021,11 +1021,15 @@ acl_app() {
 		dnsmasq_port=${GLOBAL_DNSMASQ_PORT:-11400}
 		for item in $items; do
 			index=$(expr $index + 1)
-			local enabled sid remarks sources interface tcp_no_redir_ports udp_no_redir_ports node direct_dns_query_strategy remote_dns_protocol remote_dns remote_dns_doh remote_dns_client_ip remote_dns_detour remote_fakedns remote_dns_query_strategy
+			local enabled sid remarks sources interface tcp_no_redir_ports udp_no_redir_ports node direct_dns_query_strategy remote_dns_protocol remote_dns remote_dns_doh remote_dns_client_ip remote_dns_detour remote_fakedns remote_dns_query_strategy log loglevel log_file
 			local _ip _mac _iprange _ipset _ip_or_mac source_list config_file
 			local sid=$(uci -q show "${CONFIG}.${item}" | grep "=acl_rule" | awk -F '=' '{print $1}' | awk -F '.' '{print $2}')
 			[ "$(config_n_get $sid enabled)" = "1" ] || continue
 			eval $(uci -q show "${CONFIG}.${item}" | cut -d'.' -sf 3-)
+			log=${log:-0}
+			loglevel=${loglevel:-warn}
+			log_file="/dev/null"
+			[ "${log}" = "1" ] && log_file="/tmp/log/passwall2_acl_${sid}.log"
 
 			if [ -n "${sources}" ]; then
 				for s in $sources; do
@@ -1121,7 +1125,8 @@ acl_app() {
 											direct_dns_query_strategy=${direct_dns_query_strategy} \
 											remote_dns_protocol=${remote_dns_protocol} remote_dns_tcp_server=${remote_dns} remote_dns_udp_server=${remote_dns} remote_dns_doh="${remote_dns}" \
 											remote_dns_client_ip=${remote_dns_client_ip} remote_dns_detour=${remote_dns_detour} remote_fakedns=${remote_fakedns} remote_dns_query_strategy=${remote_dns_query_strategy} \
-											config_file=${config_file}
+											config_file=${config_file} \
+											log_file="${log_file}" loglevel="${loglevel}"
 								local status=$?
 								if [ "$status" != 0 ]; then
 									log_i18n 2 "[%s] process %s error, skip this transparent proxy!" "${remarks}" "${config_file}"


### PR DESCRIPTION
### 🇨🇳 中文说明 (Chinese Description)

#### 1. 背景与动机 (Background & Rationale)
在 PassWall 2 中，访问控制 (ACL) 规则允许管理员为局域网内的特定设备（MAC/IP）分配独立的代理节点和分流策略。
在此之前，所有 ACL 规则创建的独立代理进程（如 sing-box / xray）其日志均重定向至 `/dev/null`。当某台特定 ACL 设备发生连接异常、DNS 污染或代理节点故障时，管理员无法在运行日志中看到该设备对应代理进程的报错细节，导致排查异常非常困难。

为了提升 ACL 规则的调试与排错体验，本项目为每条 ACL 规则增加了独立的“日志”与“日志等级”选项支持。

#### 2. 主要改动 (Key Changes)
* **LuCI 前端界面 (`acl_config.lua`)**:
  - 新增 **"启用日志" (`Enable Log`)** 开关（新建规则时默认保持关闭 `0`）。
  - 勾选“启用日志”后，利用 CBI 动态依赖联动，实时展开 **"日志等级" (`Log Level`)** 选择框（提供 Debug, Info, Warning, Error，默认 `warn`）。
  - 同时在前端显示服务器上的具体日志文件路径 `<code>/tmp/log/passwall2_acl_<sid>.log</code>` 便于在 SSH 中引用，同时提供一个 **"查看日志" (`View Log`)** 按钮便于在 Web 端直接查看。
* **LuCI 控制器 (`passwall2.lua`)**:
  - 新增 `get_acl_log` API 路由，当用户点击 Web 端的“查看日志”按钮时，在浏览器新标签页中调取并展示该 ACL 规则最新的日志内容。
* **后端 Service 脚本 (`app.sh`)**:
  - 在 `acl_app()` 函数解析 ACL UCI 配置时，提取每条 ACL 规则的 `log` 与 `loglevel` 参数。
  - 勾选启用后，生成专属日志文件路径 `/tmp/log/passwall2_acl_${sid}.log`，并将其透传至 `run_singbox` / `run_xray` 等核心启动函数中（完全兼容单节点、分流节点及链式代理等所有节点类型）。

#### 3. 应用示例 (Example & Usage)
假设局域网内有一台智能电视或手机，规则 ID 为 `cfg3e30ec`：
1. 管理员进入 **PassWall 2 ➔ 访问控制 ➔ 编辑规则**。
2. 勾选 **启用日志**，日志等级选择 **Debug** 并保存应用。
3. 当该设备发起网络访问时：
   - **Web 端**: 点击编辑页面中的 **"查看日志"** 按钮，弹出窗口显示该设备最新的 sing-box / xray 详细代理连接与分流日志。
   - **SSH 终端**: 连接路由器后直接执行 `tail -f /tmp/log/passwall2_acl_cfg3e30ec.log` 实时观察该设备的网络流量分流与报错信息。

---

### 🇬🇧 English Description

#### 1. Background & Rationale
In PassWall 2, Access Control (ACL) rules allow administrators to assign independent proxy nodes and routing strategies to specific LAN devices (by MAC or IP).
Previously, logs for proxy instances (such as sing-box or xray) spawned by ACL rules were hardcoded to `/dev/null`. When a specific ACL device experienced connection issues, DNS pollution, or proxy failures, administrators could not view detailed error logs for that specific device, making troubleshooting difficult.

To improve the debugging experience for ACL rules, this PR adds independent "Enable Log" and "Log Level" support for each ACL rule.

#### 2. Key Changes
* **LuCI Frontend (`acl_config.lua`)**:
  - Added **"Enable Log"** checkbox (defaults to disabled `0` for new rules).
  - When enabled, dynamically displays the **"Log Level"** selector (Debug, Info, Warning, Error; defaults to `warn`).
  - Displays the exact server log file path `<code>/tmp/log/passwall2_acl_<sid>.log</code>` for SSH reference, along with a **"View Log"** button for direct in-browser log inspection.
* **LuCI Controller (`passwall2.lua`)**:
  - Added `get_acl_log` API endpoint to render the tail of the specific ACL log file when clicking "View Log".
* **Backend Shell Script (`app.sh`)**:
  - Parsed `log` and `loglevel` settings per ACL rule item in `acl_app()`.
  - Generates `/tmp/log/passwall2_acl_${sid}.log` when log is enabled and passes `log_file` and `loglevel` arguments to core runner functions (`run_singbox`, `run_xray`, etc., fully compatible with single, shunt, and chain nodes).

#### 3. Example & Usage
Suppose a LAN device is managed by an ACL rule with ID `cfg3e30ec`:
1. Go to **PassWall 2 ➔ Access Control ➔ Edit Rule**.
2. Check **Enable Log**, set **Log Level** to **Debug**, and click Save & Apply.
3. When the device makes network requests:
   - **Web Interface**: Click the **"View Log"** button in the rule configuration to view detailed sing-box / xray proxy logs in a new tab.
   - **SSH Console**: Run `tail -f /tmp/log/passwall2_acl_cfg3e30ec.log` to observe real-time proxy connections and error tracebacks.