### PR TITLE
luci-app-passwall2: monitor queued processes

### DIFF
--- a/luci-app-passwall2/root/usr/share/passwall2/utils.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/utils.sh
@@ -409,6 +409,7 @@ ln_run() {
 
 run_process_queue() {
 	[ -d ${TMP_PROCESS_LIST_PATH} ] && {
+		mkdir -p ${TMP_SCRIPT_FUNC_PATH}
 		for filename in $(ls ${TMP_PROCESS_LIST_PATH}); do
 			cmd=$(cat ${TMP_PROCESS_LIST_PATH}/${filename})
 			cmd_check=$(echo $cmd | awk -F '>' '{print $1}')
@@ -416,7 +417,7 @@ run_process_queue() {
 			if [ $icount = 0 ]; then
 				eval $(echo "nohup ${cmd} 2>&1 &") >/dev/null 2>&1 &
 			fi
-			rm -rf ${TMP_PROCESS_LIST_PATH}/${filename}
+			mv -f ${TMP_PROCESS_LIST_PATH}/${filename} ${TMP_SCRIPT_FUNC_PATH}/queued_${filename}
 		done
 	}
 	rm -rf ${TMP_PROCESS_LIST_PATH}


### PR DESCRIPTION
## Summary

Keep commands started through `run_process_queue()` in the process monitor registry instead of deleting them after startup.

Queued entries use a separate `queued_` prefix so they do not overwrite commands that were registered directly.

## Root cause

`ln_run()` returns after adding queued commands to `process_list`. `run_process_queue()` starts those commands and removes the entries, while `monitor.sh` only checks `script_func`. As a result, a queued Xray or sing-box process is not restarted after a crash.

## Testing

- `ash -n` on OpenWrt 25.12.5
- Isolated queue test on the router
- Killed the queued test process and confirmed the monitor command restarted it with a new PID

Fixes #1195
