### PR TITLE
luci-app-passwall2: monitor queued processes

### DIFF
--- a/luci-app-passwall2/root/usr/share/passwall2/utils.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/utils.sh
@@ -409,6 +409,7 @@ ln_run() {
 
 run_process_queue() {
 	[ -d ${TMP_PROCESS_LIST_PATH} ] && {
+		mkdir -p ${TMP_SCRIPT_FUNC_PATH}
 		for filename in $(ls ${TMP_PROCESS_LIST_PATH}); do
 			cmd=$(cat ${TMP_PROCESS_LIST_PATH}/${filename})
 			cmd_check=$(echo $cmd | awk -F '>' '{print $1}')
@@ -416,7 +417,7 @@ run_process_queue() {
 			if [ $icount = 0 ]; then
 				eval $(echo "nohup ${cmd} 2>&1 &") >/dev/null 2>&1 &
 			fi
-			rm -rf ${TMP_PROCESS_LIST_PATH}/${filename}
+			mv -f ${TMP_PROCESS_LIST_PATH}/${filename} ${TMP_SCRIPT_FUNC_PATH}/queued_${filename}
 		done
 	}
 	rm -rf ${TMP_PROCESS_LIST_PATH}


### PR DESCRIPTION
## What I changed

I changed `run_process_queue()` so it keeps commands in the process monitor registry after starting them instead of deleting them.

I used a separate `queued_` prefix for these entries so they cannot overwrite commands that were registered directly.

## Why I changed it

I found that `ln_run()` returns after adding queued commands to `process_list`. `run_process_queue()` then starts those commands and removes the entries, while `monitor.sh` only checks `script_func`.

Because of that, the built-in Monitor does not restart a queued Xray or sing-box process after it is killed.

## How I tested it

- I ran `ash -n` on OpenWrt 25.12.5.
- I ran an isolated queue test on my router.
- I killed the queued test process and confirmed that the monitor command restarted it with a new PID.

Fixes #1195
