### PR TITLE
luci-app-passwall2: fix service hang when started with non-interactive stdin

### DIFF
--- a/luci-app-passwall2/root/usr/share/passwall2/nftables.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/nftables.sh
@@ -205,7 +205,9 @@ gen_nftset() {
 			nft "add set $NFTABLE_NAME $nftset_name { type $ip_type; flags interval, timeout; timeout $timeout_argument_set; gc-interval $gc_interval_time; auto-merge; }"
 		fi
 	fi
-	[ $# -gt 0 ] || [ ! -t 0 ] && insert_nftset "$nftset_name" "$timeout_argument_element" "$@"
+	if [ $# -gt 0 ]; then
+		insert_nftset "$nftset_name" "$timeout_argument_element" "$@"
+	fi
 }
 
 gen_shunt_list() {


### PR DESCRIPTION
Fixes #1201.

`gen_nftset()` forwards to `insert_nftset` when stdin is not a tty (`[ ! -t 0 ]`), even when no elements are passed. All 11 call sites of `gen_nftset` pass exactly 4 arguments and never pipe data into it, so `insert_nftset` is invoked with zero elements and falls through to the bare `cat`, blocking forever on any stdin that never reaches EOF.

This is what happens with `ssh router '/etc/init.d/passwall2 start'`: the init script inherits sshd's open channel as stdin, `cat` blocks, and the service never finishes starting. LuCI, boot and cron are unaffected (their stdin is `/dev/null`, so EOF is immediate), which is why this went unnoticed.

**Fix:** only forward to `insert_nftset` from `gen_nftset` when elements are actually passed as arguments. The stdin-reading mode of `insert_nftset` itself is untouched — all piped call sites (`... | insert_nftset set timeout`) and the `nftables.sh insert_nftset` CLI dispatch keep working unchanged. The `if` form (rather than `&&`) keeps the function's exit status at 0.

**Behavior note:** previously, with stdin at EOF, this path executed `nft -f -` with empty input (a no-op); now the call is skipped entirely, so the resulting ruleset is unchanged.

**Test plan**

- `ssh root@router '/etc/init.d/passwall2 start'` with stdin left open: hangs before the patch, completes after.
- Start with stdin redirected from `/dev/null`: still succeeds.
- Piped `insert_nftset` invocations still insert elements.
- `sh -n` passes; `gen_nftset` still returns 0 when called without elements.
