### PR TITLE
luci-app-passwall2: add TrustTunnel client node type

### DIFF
--- a/luci-app-passwall2/luasrc/controller/passwall2.lua
+++ b/luci-app-passwall2/luasrc/controller/passwall2.lua
@@ -224,8 +224,16 @@ function gen_client_config()
 	local id = http.formvalue("id")
 	local config_file = api.TMP_PATH .. "/config_" .. id
 	luci.sys.call(string.format("/usr/share/passwall2/app.sh run_socks flag=config_%s node=%s bind=127.0.0.1 socks_port=1080 config_file=%s no_run=1", id, id, config_file))
+	local content_type = "application/json"
+	-- A helper type may write its config with its own extension (TrustTunnel uses TOML).
+	-- Without this the file is neither served nor removed, and it stays in TMP_PATH with
+	-- the node credentials in it.
+	if not nixio.fs.access(config_file) and nixio.fs.access(config_file .. ".toml") then
+		config_file = config_file .. ".toml"
+		content_type = "text/plain"
+	end
 	if nixio.fs.access(config_file) then
-		http.prepare_content("application/json")
+		http.prepare_content(content_type)
 		http.write(luci.sys.exec("cat " .. config_file))
 		luci.sys.call("rm -f " .. config_file)
 	else

--- a/luci-app-passwall2/luasrc/model/cbi/passwall2/client/type/trusttunnel.lua
+++ b/luci-app-passwall2/luasrc/model/cbi/passwall2/client/type/trusttunnel.lua
@@ -1,0 +1,105 @@
+local m, s = ...
+
+if not api.finded_com("trusttunnel_client") then
+	return
+end
+
+type_name = "TrustTunnel"
+
+-- [[ TrustTunnel ]]
+
+s.fields["type"]:value(type_name, "TrustTunnel")
+
+if s.val["type"] ~= type_name then
+	return
+end
+
+local option_prefix = "trusttunnel_"
+
+local function _n(name)
+	return option_prefix .. name
+end
+
+o = s:option(Value, _n("address"), translate("Address (Support Domain Name)"))
+o.rmempty = false
+
+o = s:option(Value, _n("port"), translate("Port"))
+o.datatype = "port"
+o.rmempty = false
+
+o = s:option(Value, _n("username"), translate("Username"))
+o.rmempty = false
+
+o = s:option(Value, _n("password"), translate("Password"))
+o.password = true
+o.rmempty = false
+
+-- The client reads a "|" in the hostname as an sni|remote_id separator, which turns a
+-- pasted value containing it into a hard connect error.
+local function no_pipe(self, value)
+	value = api.trim(value)
+	if value:find("|", 1, true) then
+		return nil, translate("The character \"|\" is not allowed here.")
+	end
+	return value
+end
+
+o = s:option(Value, _n("hostname"), translate("TLS Hostname"), translate("Leave empty to use the endpoint address."))
+o.validate = no_pipe
+
+o = s:option(ListValue, _n("upstream_protocol"), translate("Upstream Protocol"))
+o:value("http2", "HTTP/2")
+o:value("http3", "HTTP/3")
+o.default = "http2"
+
+o = s:option(Value, _n("custom_sni"), translate("Custom SNI"))
+o.validate = no_pipe
+
+o = s:option(Value, _n("client_random"), translate("Client Random"))
+o.validate = function(self, value)
+	-- Lua patterns have no optional groups, so the two forms are matched separately.
+	value = api.trim(value)
+	if value == "" or value:match("^%x+$") or value:match("^%x+/%x+$") then
+		return value
+	end
+	return nil, translate("Invalid Client Random.")
+end
+
+o = s:option(TextValue, _n("certificate"), translate("TLS Certificate (PEM)"), translate("Full certificate (chain), PEM format."))
+o.rows = 5
+o.wrap = "off"
+o.validate = function(self, value)
+	value = api.trim(value):gsub("\r\n", "\n"):gsub("[ \t]*\n[ \t]*", "\n"):gsub("\n+", "\n")
+	-- Reject here rather than at service start: the generator aborts on a certificate
+	-- it cannot represent, which would otherwise leave the node silently unstartable.
+	if value ~= "" and not value:find("^%-%-%-%-%-BEGIN ") then
+		return nil, translate("Must be PEM format!")
+	end
+	return value
+end
+
+-- rmempty = false keeps LuCI from dropping a Flag that matches its default, so the
+-- generated config always states the value the form is showing.
+o = s:option(Flag, _n("has_ipv6"), translate("IPv6"))
+o.default = "1"
+o.rmempty = false
+
+o = s:option(Flag, _n("anti_dpi"), translate("Anti-DPI"))
+o.default = "0"
+
+o = s:option(Flag, _n("skip_verification"), translate("allowInsecure"), translate("Whether unsafe connections are allowed. When checked, Certificate validation will be skipped."))
+o.default = "0"
+
+o = s:option(Flag, _n("post_quantum"), translate("Post-Quantum"))
+o.default = "1"
+o.rmempty = false
+
+o = s:option(ListValue, _n("loglevel"), translate("Log Level"))
+o:value("error")
+o:value("warn")
+o:value("info")
+o:value("debug")
+o:value("trace")
+o.default = "info"
+
+api.luci_types(arg[1], m, s, type_name, option_prefix)

--- a/luci-app-passwall2/luasrc/passwall2/com.lua
+++ b/luci-app-passwall2/luasrc/passwall2/com.lua
@@ -80,4 +80,28 @@ _M.geoview = {
 	}
 }
 
+_M.trusttunnel_client = {
+	-- name:lower() must equal the binary name inside the release tarball, it is used to
+	-- locate the file after extraction.
+	name = "TrustTunnel_Client",
+	repo = "TrustTunnel/TrustTunnelClient",
+	-- Not gh_release_url: no api-cache JSON exists for this repo yet. Happy to switch
+	-- once trusttunnel is added to the api-cache workflow in openwrt-passwall-packages.
+	get_url = function(self)
+		return "https://api.github.com/repos/" .. self.repo .. "/releases/latest"
+	end,
+	cmd_version = "--version | awk '{print $2}'",
+	zipped = true,
+	zipped_suffix = "tar.gz",
+	default_path = "/usr/bin/trusttunnel_client",
+	match_fmt_str = "linux%%-%s%%.tar%%.gz$",
+	file_tree = {
+		x86_64   = "x86_64",
+		aarch64  = "aarch64",
+		armv8    = "aarch64",
+		rockchip = "aarch64",
+		armv7    = "armv7"
+	}
+}
+
 return _M

--- a/luci-app-passwall2/luasrc/passwall2/util_trusttunnel.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_trusttunnel.lua
@@ -1,0 +1,210 @@
+module("luci.passwall2.util_trusttunnel", package.seeall)
+local api = require "luci.passwall2.api"
+local uci = api.uci
+local jsonc = api.jsonc
+
+-- The client parses its config with toml++, which rejects the whole document when it is
+-- not valid UTF-8. Escaping below is byte-wise, so a Latin-1 paste or junk from an
+-- imported link would pass through unescaped and take the entire config down with an
+-- error visible only in the client log. Validate instead of silently mangling.
+local function is_utf8(s)
+	local i, n = 1, #s
+	while i <= n do
+		local c = s:byte(i)
+		local len, lo, hi
+		if c < 0x80 then
+			len = 1
+		elseif c >= 0xC2 and c <= 0xDF then
+			len, lo, hi = 2, 0x80, 0xBF
+		elseif c == 0xE0 then
+			len, lo, hi = 3, 0xA0, 0xBF
+		elseif c == 0xED then
+			len, lo, hi = 3, 0x80, 0x9F -- exclude surrogates
+		elseif c >= 0xE1 and c <= 0xEF then
+			len, lo, hi = 3, 0x80, 0xBF
+		elseif c == 0xF0 then
+			len, lo, hi = 4, 0x90, 0xBF
+		elseif c == 0xF4 then
+			len, lo, hi = 4, 0x80, 0x8F
+		elseif c >= 0xF1 and c <= 0xF3 then
+			len, lo, hi = 4, 0x80, 0xBF
+		else
+			return false
+		end
+		if i + len - 1 > n then return false end
+		for j = 1, len - 1 do
+			local cc = s:byte(i + j)
+			local min = (j == 1) and lo or 0x80
+			local max = (j == 1) and hi or 0xBF
+			if cc < min or cc > max then return false end
+		end
+		i = i + len
+	end
+	return true
+end
+
+-- Escape a Lua string for use as a TOML basic string (the "..." form).
+-- Everything that reaches the generated file comes from UCI, i.e. from the web UI,
+-- so an unescaped quote or newline would let a password inject arbitrary TOML.
+-- Returns nil when the input cannot be represented; callers must fail loudly.
+local function toml_basic(s)
+	s = tostring(s or "")
+	if not is_utf8(s) then return nil end
+	s = s:gsub("\\", "\\\\")
+	s = s:gsub('"', '\\"')
+	s = s:gsub("[%z\1-\31\127]", function(c)
+		return string.format("\\u%04X", string.byte(c))
+	end)
+	return '"' .. s .. '"'
+end
+
+-- A PEM certificate is emitted as a TOML multi-line *literal* string ('''...''').
+-- Literal strings perform no escape processing, and the PEM alphabet cannot contain
+-- a backslash or a control character other than newline. Anything that does not look
+-- like a PEM block, or that contains the literal delimiter, is rejected.
+local function toml_pem(s)
+	s = tostring(s or "")
+	if s == "" then return nil end
+	s = s:gsub("\r\n", "\n"):gsub("\r", "\n")
+	if s:find("'''", 1, true) then return nil end
+	if s:find("[%z\1-\8\11-\31\127]") then return nil end
+	if not s:find("^%-%-%-%-%-BEGIN ") then return nil end
+	if not s:find("%-%-%-%-%-%s*$") then return nil end
+	return "'''\n" .. s .. "\n'''"
+end
+
+local function toml_bool(v)
+	return (v == "1" or v == 1 or v == true) and "true" or "false"
+end
+
+function gen_config(var)
+	local node_id = var["node"]
+	if not node_id then
+		io.stderr:write("node Cannot be empty!" .. "\n")
+		return
+	end
+	local node = uci:get_all("passwall2", node_id)
+	if not node then
+		io.stderr:write("node not found!" .. "\n")
+		return
+	end
+
+	local local_socks_address = var["local_socks_address"] or "127.0.0.1"
+	local local_socks_port = var["local_socks_port"]
+	local server_host = var["server_host"] or (node.address or ""):lower()
+	local server_port = var["server_port"] or node.port
+
+	if not local_socks_port or local_socks_port == "" then
+		io.stderr:write("local socks port Cannot be empty!" .. "\n")
+		return
+	end
+	if server_host == "" or not server_port or server_port == "" then
+		io.stderr:write("endpoint address and port Cannot be empty!" .. "\n")
+		return
+	end
+
+	-- TLS SNI hostname. Falls back to the node's own address rather than to server_host:
+	-- when this node sits behind a preproxy or is a chain landing node, app.sh rewrites
+	-- server_host to 127.0.0.1, and using that would make certificate verification
+	-- impossible. node.address is the real endpoint and is never bracketed.
+	local hostname = node.hostname
+	if not hostname or hostname == "" then hostname = (node.address or ""):lower() end
+
+	if api.is_ipv6(server_host) then
+		server_host = api.get_ipv6_full(server_host)
+	end
+	if api.is_ipv6(local_socks_address) then
+		local_socks_address = api.get_ipv6_full(local_socks_address)
+	end
+	local endpoint = server_host .. ":" .. server_port
+	local listen = local_socks_address .. ":" .. local_socks_port
+
+	-- v1.0.49 rejects a config that omits vpn_mode or endpoint.upstream_protocol,
+	-- despite both being documented as having defaults. Always emit them.
+	local upstream_protocol = node.upstream_protocol
+	if upstream_protocol ~= "http3" then upstream_protocol = "http2" end
+
+	local out = {}
+	local bad = nil
+	local function put(s) out[#out + 1] = s end
+	-- toml_basic returns nil for anything it cannot represent; remember the field name
+	-- so the caller gets a specific error instead of a silently truncated config.
+	-- Empty is reported too for required fields: an empty username or password produces
+	-- a config that loads cleanly and then fails authentication forever, which is exactly
+	-- how a field-name mismatch stayed invisible once already.
+	local function str(name, v, required)
+		if required and (v == nil or v == "") then
+			bad = bad or (name .. " (empty)")
+			return '""'
+		end
+		local q = toml_basic(v)
+		if not q then bad = bad or name end
+		return q or '""'
+	end
+
+	put("# Generated by passwall2. Do not edit; changes are overwritten on restart.")
+	put("loglevel = " .. str("loglevel", node.loglevel or "info"))
+	-- Routing is owned by passwall2, so the client must tunnel everything it is given
+	-- and must never install firewall rules of its own.
+	put('vpn_mode = "general"')
+	put("killswitch_enabled = false")
+	put("exclusions = []")
+	-- LuCI drops a Flag from UCI when it matches the form default, so an absent option
+	-- means "default", not "off". Both of these default to enabled.
+	put("post_quantum_group_enabled = " .. toml_bool(node.post_quantum or "1"))
+	put("")
+	put("[endpoint]")
+	put("hostname = " .. str("hostname", hostname, true))
+	put("addresses = [" .. str("address", endpoint, true) .. "]")
+	put("username = " .. str("username", node.username, true))
+	put("password = " .. str("password", node.password, true))
+	put("upstream_protocol = " .. str("upstream_protocol", upstream_protocol, true))
+	put("has_ipv6 = " .. toml_bool(node.has_ipv6 or "1"))
+	put("anti_dpi = " .. toml_bool(node.anti_dpi))
+	put("skip_verification = " .. toml_bool(node.skip_verification))
+	if node.custom_sni and node.custom_sni ~= "" then
+		put("custom_sni = " .. str("custom_sni", node.custom_sni))
+	end
+	if node.client_random and node.client_random ~= "" then
+		put("client_random = " .. str("client_random", node.client_random))
+	end
+	-- A certificate that cannot be emitted must abort generation. Dropping it would
+	-- silently fall back to the system trust store, which is the opposite of what a
+	-- user pinning their own CA asked for, and the client only warns about a bad PEM.
+	if node.certificate and node.certificate ~= "" then
+		local pem = toml_pem(node.certificate)
+		if not pem then
+			io.stderr:write("Invalid TLS certificate (PEM)!" .. "\n")
+			return
+		end
+		put("certificate = " .. pem)
+	end
+	put("")
+	put("[listener.socks]")
+	put("address = " .. str("local socks address", listen))
+
+	if bad then
+		io.stderr:write("Invalid or missing value for " .. bad .. "!\n")
+		return
+	end
+
+	return table.concat(out, "\n") .. "\n"
+end
+
+_G.gen_config = gen_config
+
+if arg[1] then
+	local func = _G[arg[1]]
+	if func then
+		local var = nil
+		if arg[2] then
+			var = jsonc.parse(arg[2])
+		end
+		-- Never print a nil return: stdout is redirected straight into the config file
+		-- by app.sh, so "nil" would become the config and the client would be started
+		-- on it. Exit non-zero instead and leave the caller to notice.
+		local out = func(var)
+		if not out then os.exit(1) end
+		print(out)
+	end
+end

--- a/luci-app-passwall2/luasrc/passwall2/util_trusttunnel.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_trusttunnel.lua
@@ -65,6 +65,9 @@ end
 local function toml_pem(s)
 	s = tostring(s or "")
 	if s == "" then return nil end
+	-- A literal string is copied verbatim, so it needs the same UTF-8 check as the basic
+	-- strings above: toml++ rejects the whole document over one bad byte anywhere in it.
+	if not is_utf8(s) then return nil end
 	s = s:gsub("\r\n", "\n"):gsub("\r", "\n")
 	if s:find("'''", 1, true) then return nil end
 	if s:find("[%z\1-\8\11-\31\127]") then return nil end

--- a/luci-app-passwall2/luasrc/view/passwall2/node_config/link_share_man.htm
+++ b/luci-app-passwall2/luasrc/view/passwall2/node_config/link_share_man.htm
@@ -74,6 +74,101 @@ local current_node = map:get(section)
 		}
 	}
 
+
+	// TrustTunnel deep links (tt://?<base64url>) carry a TLV payload whose tags and
+	// lengths use the RFC 9000 variable-length integer encoding. See DEEP_LINK.md in
+	// the TrustTunnel repository.
+	function ttVarintRead(b, i) {
+		const n = 1 << (b[i] >> 6);
+		if (i + n > b.length) throw new Error("truncated varint");
+		let v = b[i] & 0x3f;
+		for (let k = 1; k < n; k++) v = v * 256 + b[i + k];
+		return [v, i + n];
+	}
+
+	function ttVarintWrite(v) {
+		if (v < 64) return [v];
+		if (v < 16384) return [0x40 | (v >> 8), v & 0xff];
+		if (v < 1073741824) return [0x80 | (v >> 24), (v >> 16) & 0xff, (v >> 8) & 0xff, v & 0xff];
+		throw new Error("value too large");
+	}
+
+	function ttTlvDecode(bytes) {
+		const out = [];
+		let i = 0;
+		while (i < bytes.length) {
+			let tag, len;
+			[tag, i] = ttVarintRead(bytes, i);
+			[len, i] = ttVarintRead(bytes, i);
+			if (i + len > bytes.length) throw new Error("truncated payload");
+			out.push([tag, bytes.slice(i, i + len)]);
+			i += len;
+		}
+		return out;
+	}
+
+	function ttTlvAdd(out, tag, val) {
+		out.push(...ttVarintWrite(tag), ...ttVarintWrite(val.length), ...val);
+	}
+
+	function ttUtf8Encode(s) {
+		const u = unescape(encodeURIComponent(s));
+		const b = [];
+		for (let i = 0; i < u.length; i++) b.push(u.charCodeAt(i));
+		return b;
+	}
+
+	function ttUtf8Decode(b) {
+		let s = "";
+		for (let i = 0; i < b.length; i++) s += String.fromCharCode(b[i]);
+		try { return decodeURIComponent(escape(s)); } catch (e) { return s; }
+	}
+
+	function ttBytesToStr(b) {
+		let s = "";
+		for (let i = 0; i < b.length; i++) s += String.fromCharCode(b[i]);
+		return s;
+	}
+
+	// The link carries the certificate chain as concatenated DER; the form holds PEM.
+	function ttPemToDer(pem) {
+		const out = [];
+		const blocks = pem.match(/-----BEGIN [^-]+-----[\s\S]*?-----END [^-]+-----/g) || [];
+		for (const blk of blocks) {
+			const b64 = blk.replace(/-----[^-]+-----/g, "").replace(/\s+/g, "");
+			const raw = atob(b64);
+			for (let i = 0; i < raw.length; i++) out.push(raw.charCodeAt(i));
+		}
+		return out;
+	}
+
+	function ttDerToPem(der) {
+		// The chain arrives as concatenated DER. Each certificate is an ASN.1 SEQUENCE,
+		// so the boundaries can be walked without a full parser: tag 0x30, then either a
+		// short length or 0x80|n followed by n length bytes.
+		const out = [];
+		let i = 0;
+		while (i < der.length) {
+			if (der[i] !== 0x30 || i + 2 > der.length) break;
+			let hdr = 2, len = der[i + 1];
+			if (len & 0x80) {
+				const n = len & 0x7f;
+				if (n === 0 || n > 4 || i + 2 + n > der.length) break;
+				len = 0;
+				for (let k = 0; k < n; k++) len = len * 256 + der[i + 2 + k];
+				hdr = 2 + n;
+			}
+			const end = i + hdr + len;
+			if (end > der.length) break;
+			const b64 = btoa(ttBytesToStr(der.slice(i, end)));
+			let body = "";
+			for (let k = 0; k < b64.length; k += 64) body += b64.substring(k, k + 64) + "\n";
+			out.push("-----BEGIN CERTIFICATE-----\n" + body + "-----END CERTIFICATE-----");
+			i = end;
+		}
+		return out.join("\n");
+	}
+
 	function dictvalue(d, key) {
 		var v = d[key];
 		if (typeof (v) === 'undefined' || v === '')
@@ -173,6 +268,9 @@ local current_node = map:get(section)
 		} else if (v_type === "Hysteria2") {
 			dom_prefix = "hysteria2_"
 			protocol = "hysteria2"
+		} else if (v_type === "TrustTunnel") {
+			dom_prefix = "trusttunnel_"
+			protocol = "tt"
 		} else if (v_type === "Xray") {
 			dom_prefix = "xray_"
 		} else if (v_type === "sing-box") {
@@ -713,6 +811,41 @@ local current_node = map:get(section)
 				params = params.substring(1);
 			}
 			url += params;
+		} else if (v_type === "TrustTunnel") {
+			var payload = [];
+			var tt_str = function(tag, id) {
+				var e = opt.get(dom_prefix + id);
+				if (e && e.value && e.value.trim() !== "") ttTlvAdd(payload, tag, ttUtf8Encode(e.value.trim()));
+			};
+			var tt_bool = function(tag, id, dflt) {
+				var e = opt.get(dom_prefix + id);
+				var v = e ? !!e.checked : dflt;
+				if (v !== dflt) ttTlvAdd(payload, tag, [v ? 1 : 0]);
+			};
+			ttTlvAdd(payload, 0, [1]);
+			var tt_host = opt.get(dom_prefix + "hostname");
+			var tt_addr_raw = opt.get(dom_prefix + "address");
+			var tt_hostname = (tt_host && tt_host.value.trim() !== "") ? tt_host.value.trim()
+				: (tt_addr_raw ? tt_addr_raw.value.trim() : _address);
+			ttTlvAdd(payload, 1, ttUtf8Encode(tt_hostname));
+			ttTlvAdd(payload, 2, ttUtf8Encode(_address + ":" + opt.get(dom_prefix + "port").value));
+			tt_str(3, "custom_sni");
+			tt_bool(4, "has_ipv6", true);
+			tt_str(5, "username");
+			tt_str(6, "password");
+			tt_bool(7, "skip_verification", false);
+			var tt_pem = opt.get(dom_prefix + "certificate");
+			if (tt_pem && tt_pem.value.trim() !== "") {
+				var der = ttPemToDer(tt_pem.value);
+				if (der.length) ttTlvAdd(payload, 8, der);
+			}
+			var tt_up = opt.get(dom_prefix + "upstream_protocol");
+			if (tt_up && tt_up.value === "http3") ttTlvAdd(payload, 9, [2]);
+			tt_bool(10, "anti_dpi", false);
+			tt_str(11, "client_random");
+			if (v_alias && v_alias.value.trim() !== "") ttTlvAdd(payload, 12, ttUtf8Encode(v_alias.value.trim()));
+			url = "?" + b64encsafe(ttBytesToStr(payload));
+			return "tt://" + url;
 		}
 		if (url) {
 			url = protocol.toLowerCase() + "://" + url;
@@ -1718,6 +1851,74 @@ local current_node = map:get(section)
 				opt.set('remarks', decodeURIComponent(hash.substr(1)));
 			}
 		}
+		if (ssu[0] === "tt") {
+			dom_prefix = "trusttunnel_"
+			opt.set('type', "TrustTunnel");
+			var tt_payload = (ssu[1] || "").replace(/^\?/, "").replace(/#.*/, "").trim();
+			var tt_entries = null;
+			try {
+				var tt_raw = b64decsafe(tt_payload), tt_bytes = [];
+				for (var i = 0; i < tt_raw.length; i++) tt_bytes.push(tt_raw.charCodeAt(i));
+				tt_entries = ttTlvDecode(tt_bytes);
+			} catch (e) {
+				tt_entries = null;
+			}
+			if (!tt_entries || !tt_entries.length) {
+				s.innerHTML = "<font color='red'><%:Invalid Share URL Format%></font>";
+				return false;
+			}
+			var tt = {}, tt_addr = [], tt_der = [];
+			for (var i = 0; i < tt_entries.length; i++) {
+				var tag = tt_entries[i][0], val = tt_entries[i][1];
+				if (tag === 2) tt_addr.push(ttUtf8Decode(val));
+				else if (tag === 8) tt_der = tt_der.concat(val);
+				else tt[tag] = val;
+			}
+			if (!tt_addr.length || tt[1] === undefined || tt[5] === undefined || tt[6] === undefined) {
+				s.innerHTML = "<font color='red'><%:Invalid Share URL Format%></font>";
+				return false;
+			}
+			if (tt[0] !== undefined && ttVarintRead(tt[0], 0)[0] > 1) {
+				s.innerHTML = "<font color='red'><%:Unsupported share link version.%></font>";
+				return false;
+			}
+			var tt_first = tt_addr[0];
+			var tt_sep = tt_first.lastIndexOf(":");
+			if (tt_sep <= 0) {
+				s.innerHTML = "<font color='red'><%:Invalid Share URL Format%></font>";
+				return false;
+			}
+			opt.set(dom_prefix + 'address', unbracketIP(tt_first.substring(0, tt_sep)));
+			opt.set(dom_prefix + 'port', tt_first.substring(tt_sep + 1) || "443");
+			opt.set(dom_prefix + 'hostname', ttUtf8Decode(tt[1]));
+			opt.set(dom_prefix + 'username', ttUtf8Decode(tt[5]));
+			opt.set(dom_prefix + 'password', ttUtf8Decode(tt[6]));
+			opt.set(dom_prefix + 'custom_sni', tt[3] !== undefined ? ttUtf8Decode(tt[3]) : '');
+			opt.set(dom_prefix + 'client_random', tt[11] !== undefined ? ttUtf8Decode(tt[11]) : '');
+			opt.set(dom_prefix + 'has_ipv6', tt[4] !== undefined ? tt[4][0] === 1 : true);
+			opt.set(dom_prefix + 'skip_verification', tt[7] !== undefined ? tt[7][0] === 1 : false);
+			opt.set(dom_prefix + 'anti_dpi', tt[10] !== undefined ? tt[10][0] === 1 : false);
+			opt.set(dom_prefix + 'upstream_protocol', (tt[9] !== undefined && ttVarintRead(tt[9], 0)[0] === 2) ? "http3" : "http2");
+			opt.set(dom_prefix + 'certificate', tt_der.length ? ttDerToPem(tt_der) : '');
+			var tt_name = tt_first;
+			if (tt[12] !== undefined) {
+				tt_name = ttUtf8Decode(tt[12]);
+			} else if (ssrurl.indexOf("#") > -1) {
+				try { tt_name = decodeURI(ssrurl.split("#")[1]); } catch (e) { }
+			}
+			opt.set('remarks', tt_name);
+			// dns_upstreams (tag 13) is dropped on purpose: passwall2 owns DNS.
+			if (opt.get(dom_prefix + 'port').value) {
+				opt.get(dom_prefix + 'port').focus();
+				opt.get(dom_prefix + 'port').blur();
+			}
+			sessionStorage.removeItem("fromUrl");
+			s.innerHTML = (tt_addr.length > 1)
+				? "<font color='orange'><%:Only the first endpoint address was imported.%></font>"
+				: "<font color='green'><%:Import Finished %></font>";
+			return true;
+		}
+
 		if (ssu[0] === "anytls") {
 			if (has_singbox) {
 				dom_prefix = "singbox_"

--- a/luci-app-passwall2/po/fa/passwall2.po
+++ b/luci-app-passwall2/po/fa/passwall2.po
@@ -2447,3 +2447,9 @@ msgstr ""
 
 msgid "Must be PEM format!"
 msgstr ""
+
+msgid "Only the first endpoint address was imported."
+msgstr ""
+
+msgid "Unsupported share link version."
+msgstr ""

--- a/luci-app-passwall2/po/fa/passwall2.po
+++ b/luci-app-passwall2/po/fa/passwall2.po
@@ -2413,3 +2413,37 @@ msgstr "اندازه بسته Gecko (حداکثر)"
 
 msgid "valid time (hh:mm)"
 msgstr "زمان معتبر (ساعت:میلی‌متر)"
+
+
+msgid "TLS Hostname"
+msgstr ""
+
+msgid "Leave empty to use the endpoint address."
+msgstr ""
+
+msgid "Upstream Protocol"
+msgstr ""
+
+msgid "Custom SNI"
+msgstr ""
+
+msgid "Client Random"
+msgstr ""
+
+msgid "Invalid Client Random."
+msgstr ""
+
+msgid "Anti-DPI"
+msgstr ""
+
+msgid "Post-Quantum"
+msgstr ""
+
+msgid "The character \"|\" is not allowed here."
+msgstr ""
+
+msgid "Socks node: [%s]%s, config generation failed."
+msgstr ""
+
+msgid "Must be PEM format!"
+msgstr ""

--- a/luci-app-passwall2/po/ru/passwall2.po
+++ b/luci-app-passwall2/po/ru/passwall2.po
@@ -2445,3 +2445,9 @@ msgstr "Socks-узел: [%s]%s, не удалось сгенерировать �
 
 msgid "Must be PEM format!"
 msgstr "Должно быть в формате PEM!"
+
+msgid "Only the first endpoint address was imported."
+msgstr "Импортирован только первый адрес эндпоинта."
+
+msgid "Unsupported share link version."
+msgstr "Версия ссылки не поддерживается."

--- a/luci-app-passwall2/po/ru/passwall2.po
+++ b/luci-app-passwall2/po/ru/passwall2.po
@@ -2411,3 +2411,37 @@ msgstr "Размер упаковки Gecko (макс)"
 
 msgid "valid time (hh:mm)"
 msgstr "Время действия (чч:мм)"
+
+
+msgid "TLS Hostname"
+msgstr "Имя хоста TLS"
+
+msgid "Leave empty to use the endpoint address."
+msgstr "Оставьте пустым, чтобы использовать адрес эндпоинта."
+
+msgid "Upstream Protocol"
+msgstr "Протокол подключения"
+
+msgid "Custom SNI"
+msgstr "Пользовательский SNI"
+
+msgid "Client Random"
+msgstr "Client Random"
+
+msgid "Invalid Client Random."
+msgstr "Неверное значение Client Random."
+
+msgid "Anti-DPI"
+msgstr "Противодействие DPI"
+
+msgid "Post-Quantum"
+msgstr "Постквантовая криптография"
+
+msgid "The character \"|\" is not allowed here."
+msgstr "Символ «|» здесь недопустим."
+
+msgid "Socks node: [%s]%s, config generation failed."
+msgstr "Socks-узел: [%s]%s, не удалось сгенерировать конфигурацию."
+
+msgid "Must be PEM format!"
+msgstr "Должно быть в формате PEM!"

--- a/luci-app-passwall2/po/zh-cn/passwall2.po
+++ b/luci-app-passwall2/po/zh-cn/passwall2.po
@@ -2399,3 +2399,37 @@ msgstr "Gecko 包大小（最大）"
 
 msgid "valid time (hh:mm)"
 msgstr "有效时间（hh:mm）"
+
+
+msgid "TLS Hostname"
+msgstr "TLS 主机名"
+
+msgid "Leave empty to use the endpoint address."
+msgstr "留空则使用端点地址。"
+
+msgid "Upstream Protocol"
+msgstr "上游协议"
+
+msgid "Custom SNI"
+msgstr "自定义 SNI"
+
+msgid "Client Random"
+msgstr "客户端随机数"
+
+msgid "Invalid Client Random."
+msgstr "客户端随机数无效。"
+
+msgid "Anti-DPI"
+msgstr "反 DPI"
+
+msgid "Post-Quantum"
+msgstr "后量子密钥交换"
+
+msgid "The character \"|\" is not allowed here."
+msgstr "此处不允许使用字符“|”。"
+
+msgid "Socks node: [%s]%s, config generation failed."
+msgstr "Socks 节点：[%s]%s，配置生成失败。"
+
+msgid "Must be PEM format!"
+msgstr "必须为 PEM 格式！"

--- a/luci-app-passwall2/po/zh-cn/passwall2.po
+++ b/luci-app-passwall2/po/zh-cn/passwall2.po
@@ -2433,3 +2433,9 @@ msgstr "Socks 节点：[%s]%s，配置生成失败。"
 
 msgid "Must be PEM format!"
 msgstr "必须为 PEM 格式！"
+
+msgid "Only the first endpoint address was imported."
+msgstr "仅导入了第一个端点地址。"
+
+msgid "Unsupported share link version."
+msgstr "不支持的分享链接版本。"

--- a/luci-app-passwall2/po/zh-tw/passwall2.po
+++ b/luci-app-passwall2/po/zh-tw/passwall2.po
@@ -2439,3 +2439,9 @@ msgstr "Socks 節點：[%s]%s，設定產生失敗。"
 
 msgid "Must be PEM format!"
 msgstr "必須為 PEM 格式！"
+
+msgid "Only the first endpoint address was imported."
+msgstr "僅匯入了第一個端點位址。"
+
+msgid "Unsupported share link version."
+msgstr "不支援的分享連結版本。"

--- a/luci-app-passwall2/po/zh-tw/passwall2.po
+++ b/luci-app-passwall2/po/zh-tw/passwall2.po
@@ -2405,3 +2405,37 @@ msgstr "Gecko 包大小（最大）"
 
 msgid "valid time (hh:mm)"
 msgstr "有效時間（hh:mm）"
+
+
+msgid "TLS Hostname"
+msgstr "TLS 主機名稱"
+
+msgid "Leave empty to use the endpoint address."
+msgstr "留空則使用端點位址。"
+
+msgid "Upstream Protocol"
+msgstr "上游協定"
+
+msgid "Custom SNI"
+msgstr "自訂 SNI"
+
+msgid "Client Random"
+msgstr "用戶端隨機數"
+
+msgid "Invalid Client Random."
+msgstr "用戶端隨機數無效。"
+
+msgid "Anti-DPI"
+msgstr "反 DPI"
+
+msgid "Post-Quantum"
+msgstr "後量子金鑰交換"
+
+msgid "The character \"|\" is not allowed here."
+msgstr "此處不允許使用字元「|」。"
+
+msgid "Socks node: [%s]%s, config generation failed."
+msgstr "Socks 節點：[%s]%s，設定產生失敗。"
+
+msgid "Must be PEM format!"
+msgstr "必須為 PEM 格式！"

--- a/luci-app-passwall2/root/usr/share/passwall2/0_default_config
+++ b/luci-app-passwall2/root/usr/share/passwall2/0_default_config
@@ -53,6 +53,7 @@ config global_app
 	option xray_file '/usr/bin/xray'
 	option hysteria_file '/usr/bin/hysteria'
 	option sing_box_file '/usr/bin/sing-box'
+	option trusttunnel_client_file '/usr/bin/trusttunnel_client'
 
 config global_subscribe
 	option filter_keyword_mode '1'

--- a/luci-app-passwall2/root/usr/share/passwall2/app.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/app.sh
@@ -14,6 +14,7 @@ UTIL_SS=$LUA_UTIL_PATH/util_shadowsocks.lua
 UTIL_XRAY=$LUA_UTIL_PATH/util_xray.lua
 UTIL_NAIVE=$LUA_UTIL_PATH/util_naiveproxy.lua
 UTIL_HYSTERIA2=$LUA_UTIL_PATH/util_hysteria2.lua
+UTIL_TRUSTTUNNEL=$LUA_UTIL_PATH/util_trusttunnel.lua
 SINGBOX_BIN=$(first_type $(config_t_get global_app sing_box_file) sing-box)
 XRAY_BIN=$(first_type $(config_t_get global_app xray_file) xray)
 
@@ -495,6 +496,18 @@ run_socks() {
 		local _json_arg="$(json_dump)"
 		lua $UTIL_HYSTERIA2 gen_config "${_json_arg}" > $config_file
 		[ -z "$no_run" ] && ln_run ${QUEUE_RUN} "$(first_type $(config_t_get global_app hysteria_file))" "hysteria" $log_file -c "$config_file" client
+	;;
+	trusttunnel)
+		json_add_string "local_socks_address" "${bind}"
+		json_add_string "local_socks_port" "${socks_port}"
+		config_file="${config_file%.json}.toml"
+		local _json_arg="$(json_dump)"
+		if ! lua $UTIL_TRUSTTUNNEL gen_config "${_json_arg}" > $config_file || [ ! -s "$config_file" ]; then
+			rm -f "$config_file"
+			log 1 "$(i18n "Socks node: [%s]%s, config generation failed." "${remarks}" "${tmp}")"
+			return 1
+		fi
+		[ -z "$no_run" ] && ln_run ${QUEUE_RUN} "$(first_type $(config_t_get global_app trusttunnel_client_file /usr/bin/trusttunnel_client))" "trusttunnel_client" $log_file -c "$config_file"
 	;;
 	esac
 


### PR DESCRIPTION
### What this adds

A `TrustTunnel` client node type, so passwall2 can own and supervise the official TrustTunnel CLI client the same way it already does for Hysteria2 and NaiveProxy.

[TrustTunnel](https://github.com/TrustTunnel/TrustTunnel) is a VPN protocol developed by AdGuard VPN and open-sourced under Apache-2.0. The endpoint (Rust) and the [client](https://github.com/TrustTunnel/TrustTunnelClient) (C++) are both public, the wire format is documented in `PROTOCOL.md`, and the client publishes static release builds for `linux-x86_64`, `aarch64`, `armv7`, `mips` and `mipsel` — the common OpenWrt architectures. It speaks HTTP/2 or HTTP/3 over TLS and tunnels TCP, UDP and ICMP.

Today it can only be used here by running the client out of band and pointing a `Socks` node at its listener, which means the endpoint has to be excluded from the tunnel by hand or the client routes itself through itself.

### How it works

The node stores the **real remote endpoint** in `address`/`port` and the client is launched as an ordinary helper. That is the whole design, and it is why no firewall or routing code changes:

- `run_socks` appends the node to `direct_node_list` (`app.sh`), so the OUTPUT return rule for the endpoint is created automatically;
- `helper_dnsmasq.lua` already pins every node's domain-form `address` to the local resolver and the direct nftset (literal IPs need no pinning — the return rule above covers them);
- `gen_outbound` in `util_xray.lua` / `util_sing-box.lua` is **not touched** — the existing foreign-core path allocates a local port, calls `run_socks`, and substitutes a socks outbound.

The client is configured through TOML. There is no TOML library in this tree, so `util_trusttunnel.lua` emits it directly.

### Notes on the implementation

**Escaping.** Everything in the generated config comes from the web UI, so this is a security boundary rather than cosmetics: without escaping, a password containing a quote and a newline can append arbitrary TOML — for example a second `[listener.socks]` table rebinding the proxy to `0.0.0.0`. Values are also validated as UTF-8, because the client parses with toml++, which rejects an entire document that is not.

**Errors go to stderr and exit non-zero, and `app.sh` refuses to launch on a failed or empty config.** This is the one place the patch deliberately diverges from the sibling generators. Their trailer prints the return value of `gen_config` straight to stdout, and `app.sh` redirects stdout into the config file — so a diagnostic would *become* the config, the client would be started on it, fail to parse, and `monitor.sh` would retry it every 58 s forever. That never mattered before because no sibling generator aborts on user input; this one does.

**Two client behaviours are worth stating.** v1.0.49 rejects a config that omits `vpn_mode` or `endpoint.upstream_protocol` despite both being documented as defaulted, so both are always emitted. And LuCI drops a `Flag` whose submitted value equals the form default, so an absent option means "default", not "off" — `has_ipv6` and `post_quantum` set `rmempty = false` and the generator treats absence as enabled.

**`killswitch_enabled` is always `false` and the listener is always `socks`.** passwall2 owns routing and nftables; a second owner of either would fight it.

### Share links

The second commit adds build and import for `tt://` deep links ([DEEP_LINK.md](https://github.com/TrustTunnel/TrustTunnel/blob/master/DEEP_LINK.md)) — a TLV payload with RFC 9000 varints. The certificate is converted between the link's concatenated DER and the form's PEM by walking the ASN.1 SEQUENCE headers; `dns_upstreams` is dropped on import since passwall2 owns DNS. The decoder refuses truncated varints, unsupported versions and portless addresses rather than importing a half-formed node, and the import path clears the cached paste so `sessionStorage` does not replay it on later page loads.

Verified in a browser on the live router: a link exported from a node was accepted by the project's own QR page, and a link produced there imported back into a working node with every field intact. Reloading the page after an import correctly does nothing. The codec itself was also exercised outside the browser — byte-identical TLV re-encode of a genuine link, varint boundaries, repeated address tags, non-ASCII names, real one- and two-certificate chains, and malformed payloads.

### Deliberately omitted

- **TUN mode** — would take routing away from passwall2.
- **Subscription import** — not implemented. `subscribe.lua` parses its own formats and TrustTunnel links are not distributed that way today; the share-link code in this PR is the reusable half if that changes.
- **HTTP listener** — not needed: the generic http-to-socks bridge after the `case` in `run_socks` already covers this type.

### One thing that needs a maintainer

`com.lua` points `get_url` straight at `api.github.com` rather than using `gh_release_url`, because no api-cache JSON exists for this repo — those are generated by CI in `openwrt-passwall-packages`, which I cannot extend. Failure degrades gracefully to "Get remote version info failed". Happy to switch this entry to `gh_release_url` in a follow-up once `trusttunnel_client` is added to the api-cache workflow, or to open a companion PR there if that helps.

Also note `name` must lower-case to exactly `trusttunnel_client`, since `api.lua` uses it to locate the binary inside the extracted tarball — hence `TrustTunnel_Client` rather than a prettier label.

### Testing

On OpenWrt 24.10.1, `mediatek/filogic`, `aarch64_cortex-a53`, fw4/nftables, client v1.0.49.

Torn down to a clean tree and reinstalled from scratch to confirm the flow works end to end:

- binary downloaded through the **App Update** page — correct arch selected, extracted and installed, version check works;
- node created through the **web form**;
- generated config compared field by field against a known-good hand-written one, including the password checksum — identical;
- **TCP** through the node returns the expected egress IP. The node-list URL test works too, which is worth noting because it launches the client cold and probes after a fixed `sleep 2s` (`test.sh`) — a slow-starting client would read as permanently dead there. This one answers `generate_204` in 0.28 s;
- **UDP** verified with a real SOCKS5 `UDP ASSOCIATE` (an xray `dokodemo-door` probe routed through the node's listener), not inferred;
- **endpoint bypass** confirmed automatic — the node id appears in `direct_node_list` and the return rules are present for both TCP and UDP;
- **negative path**: a node with an empty credential, or a certificate that is not valid UTF-8, aborts generation, leaves no config file behind and starts no process;
- generator exercised against hostile input — a password crafted to inject `[listener.socks] address = "0.0.0.0:1080"`, backslashes, control characters, invalid UTF-8, non-ASCII, an IPv6 endpoint and a PEM containing the literal `'''` — every result parsed back with an independent TOML parser.

It is now the live path on that router, carrying household traffic with the shunt rules still splitting domestic traffic direct.

Not verified: MIPS hardware (the release assets and the arch mapping exist, but I have no device); iptables/fw3 (tested on fw4/nftables only); use as a chain or preproxy hop — the `hostname` fallback in the generator is written for that path but was not exercised; and the v1.1.x prerelease line (v1.0.49 is the current stable release).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
