### PR TITLE
Fix: 3 Code scanning alerts

### DIFF
--- a/luci-app-passwall2/luasrc/view/passwall2/node_config/footer.htm
+++ b/luci-app-passwall2/luasrc/view/passwall2/node_config/footer.htm
@@ -48,7 +48,7 @@
 							protocol: getOption("<%=self.config%>", "<%=self.section%>", name).value,
 						}, node_config_url);
 					} else {
-						window.location.href = node_config_url + "?select_proto=" + el.value;
+						window.location.href = node_config_url + "?select_proto=" + encodeURIComponent(el.value);
 					}
 				}
 			});

--- a/luci-app-passwall2/luasrc/view/passwall2/node_list/node_list.htm
+++ b/luci-app-passwall2/luasrc/view/passwall2/node_list/node_list.htm
@@ -1129,7 +1129,7 @@ table td, .table .td {
 		add_node() {
 			let nodes_link = document.getElementById("nodes_link").value;
 			const group = (document.querySelector('#addlink_group_custom input[type="hidden"]')?.value || "default");
-			nodes_link = nodes_link.replace(/\t/g, "").replace(/\r\n|\r/g, "\n").replace(/<[^>]*>/g, '').trim();
+			nodes_link = nodes_link.replace(/\t/g, "").replace(/\r\n|\r/g, "\n").replace(/[<>]/g, '').trim();
 			if (nodes_link != "") {
 				nodes_link = decodeIfBase64(nodes_link);
 				let s = nodes_link.split('://');

--- a/luci-app-passwall2/luasrc/view/passwall2/node_list/node_list.htm
+++ b/luci-app-passwall2/luasrc/view/passwall2/node_list/node_list.htm
@@ -1257,7 +1257,7 @@ table td, .table .td {
 			this.section = cbi_id;
 			document.getElementById("set_node_div").style.display="block";
 			const node_name = document.getElementById("cbid.<%=appname%>." + cbi_id + ".remarks").value;
-			document.getElementById("set_node_name").innerHTML = node_name;
+			document.getElementById("set_node_name").textContent = node_name;
 		},
 		close() {
 			document.getElementById("set_node_div").style.display="none";

--- a/luci-app-passwall2/luasrc/view/passwall2/node_list/node_list.htm
+++ b/luci-app-passwall2/luasrc/view/passwall2/node_list/node_list.htm
@@ -1129,7 +1129,7 @@ table td, .table .td {
 		add_node() {
 			let nodes_link = document.getElementById("nodes_link").value;
 			const group = (document.querySelector('#addlink_group_custom input[type="hidden"]')?.value || "default");
-			nodes_link = nodes_link.replace(/\t/g, "").replace(/\r\n|\r/g, "\n").replace(/[<>]/g, '').trim();
+			nodes_link = nodes_link.replace(/\t/g, "").replace(/\r\n|\r/g, "\n").replace(/<[^>]*>/g, '').trim();
 			if (nodes_link != "") {
 				nodes_link = decodeIfBase64(nodes_link);
 				let s = nodes_link.split('://');
@@ -1261,12 +1261,12 @@ table td, .table .td {
 		},
 		close() {
 			document.getElementById("set_node_div").style.display="none";
-			document.getElementById("set_node_name").innerHTML = "";
+			document.getElementById("set_node_name").textContent = "";
 		},
 		set(type, config) {
 			if (confirm('<%:Are you sure set this node?%>') == true){
 				ajax.abortAll();
-				window.location.href = '<%=api.url("set_node")%>?type=' + type + '&config=' + config + '&section=' + section;
+				window.location.href = '<%=api.url("set_node")%>?type=' + type + '&config=' + config + '&section=' + this.section;
 			}
 		}
 	}


### PR DESCRIPTION
1. DOM text reinterpreted as HTML :
- luci-app-passwall2/luasrc/view/passwall2/node_config/footer.htm:51 `window.location.href = node_config_url + "?select_proto=" + el.value;`
- luci-app-passwall2/luasrc/view/passwall2/node_list/node_list.htm:1260 `document.getElementById("set_node_name").innerHTML = node_name;`

2. Incomplete multi-character sanitization:
- luci-app-passwall2/luasrc/view/passwall2/node_list/node_list.htm:1132 `nodes_link = nodes_link.replace(/\t/g, "").replace(/\r\n|\r/g, "\n").replace(/<[^>]*>/g, '').trim();`