### PR TITLE
fix(dns): keep global dns.strategy dual-stack (don't leak single-stack to other DNS path)

### DIFF
--- a/luci-app-passwall2/luasrc/passwall2/util_sing-box.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_sing-box.lua
@@ -1982,7 +1982,12 @@ function gen_config(var)
 		else default_dns_flag = "direct"
 		end
 		dns.final = default_dns_flag
-		dns.strategy = default_dns_flag == "remote" and remote_strategy or direct_strategy
+		-- Single-stack (ipv4_only / ipv6_only) is enforced per-domain via the
+		-- query_type / reject rules generated below. The global dns.strategy applies
+		-- to every DNS server that does not set its own query_strategy, so keep it
+		-- dual-stack; otherwise a single-stack choice on one path would also force the
+		-- other path (e.g. direct / CN domains) into single-stack. See issue #1220.
+		dns.strategy = "prefer_ipv6"
 
 		-- DNS in order of shunt
 		if dns_domain_rules and #dns_domain_rules > 0 then


### PR DESCRIPTION
## Root cause

In `util_sing-box.lua`, `dns.strategy` (the global DNS strategy applied to every DNS server that does not set its own `query_strategy`) was collapsed from `default_dns_flag`:

```lua
dns.strategy = default_dns_flag == "remote" and remote_strategy or direct_strategy
```

`remote_strategy` / `direct_strategy` can be `ipv4_only` / `ipv6_only`. Because sing-box applies the global `dns.strategy` to **all** DNS servers (none set their own `query_strategy` on 1.13), picking `UseIPv4`/`UseIPv6` on **one** path (e.g. remote) silently forced the **other** path (e.g. direct / CN domains) into single-stack too.

Concretely: with `Remote Query Strategy = UseIPv4` the generated config had `dns.strategy: "ipv4_only"` globally, so even domestic (direct) domains lost their AAAA records.

## Fix

Single-stack (`ipv4_only` / `ipv6_only`) is already enforced **per-domain** via the `query_type` / `reject` rules generated later in the same function, so the global `dns.strategy` only needs to stay dual-stack. Keep it dual-stack (`prefer_ipv6`) and let the per-domain rules do the single-stack restriction.

This makes the direct/remote query strategies independent: e.g. `Remote = UseIPv4` now correctly yields foreign = IPv4-only while domestic stays dual-stack, instead of killing AAAA everywhere.

Fixes #1220
