### PR TITLE
socks_auto_switch: port test_url hardening (max_time cap + recheck) from openwrt-passwall

### DIFF
--- a/luci-app-passwall2/root/usr/share/passwall2/socks_auto_switch.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/socks_auto_switch.sh
@@ -18,15 +18,35 @@ test_url() {
 	local timeout=2
 	[ -n "$3" ] && timeout=$3
 	local extra_params=$4
-	if /usr/bin/curl --help all | grep -q "\-\-retry-all-errors"; then
-		extra_params="--retry-all-errors ${extra_params}"
+	local repeat=$5
+
+	if [ -z "$curl_retry_all_errors" ]; then
+		if /usr/bin/curl --help all | grep -q "\-\-retry-all-errors"; then
+			curl_retry_all_errors=1
+		fi
 	fi
-	local status=$(/usr/bin/curl -I -o /dev/null -skL ${extra_params} --connect-timeout ${timeout} --retry ${try} -w %{http_code} "$url")
+	[ "$curl_retry_all_errors" = "1" ] && extra_params="--retry-all-errors ${extra_params}"
+
+	local max_time=$((timeout * (try + 1) + try + 3))
+	curl_test() {
+		/usr/bin/curl -I -o /dev/null -skL ${extra_params} --max-time ${max_time} --connect-timeout ${timeout} --retry ${try} --retry-delay 1 -w "%{http_code}" "$url"
+	}
+
+	local status=$(curl_test)
 	case "$status" in
 		204)
 			status=200
 		;;
 	esac
+	if [ "$status" = "200" ] && [ "$repeat" = "1" ]; then
+		sleep 3s
+		status=$(curl_test)
+		case "$status" in
+			204)
+				status=200
+			;;
+		esac
+	fi
 	echo $status
 }
 
@@ -59,7 +79,7 @@ test_node() {
 		NO_REC_PROCESS=1 $APP_FILE run_socks flag="test_node_${node_id}" node=${node_id} bind=127.0.0.1 socks_port=${_tmp_port} config_file=test_node_${node_id}.json
 		sleep 2s
 		local curlx="socks5h://127.0.0.1:${_tmp_port}"
-		local _proxy_status=$(test_url "${probe_url}" ${retry_num} ${connect_timeout} "-x $curlx")
+		local _proxy_status=$(test_url "${probe_url}" ${retry_num} ${connect_timeout} "-x $curlx" 1)
 		# Kill the SS plugin process
 		local pid_file="/tmp/etc/${CONFIG}/test_node_${node_id}_plugin.pid"
 		[ -s "$pid_file" ] && kill -9 "$(head -n 1 "$pid_file")" >/dev/null 2>&1


### PR DESCRIPTION
## 概述
将 `openwrt-passwall`（v1）`socks_auto_switch.sh` 中 `test_url()` 的健壮性加固移植到 pw2，解决 pw2 当前在节点探测上的两个已知缺陷：

1. **缺少 `--max-time` 总时限**：旧逻辑 `curl` 无总超时，节点“连上但不回响应头”的半死状态时，单次探测会无限挂起，导致自动切换逻辑被卡死。
2. **缺少二次复检**：单次成功即判定存活，弱网瞬时抖动容易误切节点。

## 改动
- `test_url()` 新增：
  - `curl_retry_all_errors` 缓存（避免每次探测都 `curl --help` 探测能力，周期探活每 `testing_time` 秒跑一次，省开销）；
  - `max_time=$((timeout*(try+1)+try+3))` 总时限，杜绝半死挂起；
  - 命中 200 且 `repeat=1` 时 `sleep 3s` 后二次复检一次，避免瞬时误判（3s 沿用 pw 现有硬编码，未新增配置项）；
  - 补 `--retry-delay 1`。
- `test_node()` 调用补第 5 参 `1` 触发复检，与 pw 行为一致（`test_proxy` 周期探活仅获得 `max_time` 封顶，复检仍只作用于手动切/测节点，忠实对齐 pw）。

## 验证
逻辑对齐 pw `8ac81b1b8f` 的 `test_url` 加固；shell 语法静态检查通过。建议在设备上以弱网/半死节点实测探活不再挂起、切换不再误触。

注：本 PR 不新增任何 LuCI 配置项，3s 复检间隔保持与上游一致的硬编码实现。
