### PR TITLE
luci-app-passwall2: restart after NTP time becomes valid on RTC-less devices

### DIFF
--- a/luci-app-passwall2/root/etc/hotplug.d/ntp/30-passwall2-resync
+++ b/luci-app-passwall2/root/etc/hotplug.d/ntp/30-passwall2-resync
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Devices without a hardware RTC boot with a wrong system clock: sysfixtime can
+# only restore the mtime of the newest file under /etc, so the clock is usually
+# hours behind after a cold boot. passwall2 is then started by
+# /etc/hotplug.d/iface/98-passwall2 on ifup, which typically happens before NTP
+# has corrected the time, and time-sensitive handshakes (VMess AEAD, TLS) fail.
+#
+# Nothing restarts passwall2 once the clock is corrected, so it stays broken
+# until the user restarts it manually. Restart once when ntpd reports that the
+# time is valid -- the same approach dnsmasq uses for DNSSEC in
+# /etc/hotplug.d/ntp/25-dnsmasqsec.
+
+[ "$ACTION" = "stratum" ] || exit 0
+
+. /usr/share/passwall2/utils.sh
+
+NTP_LOCK_FILE="${LOCK_PATH}/${CONFIG}_ntp.lock"
+[ -f "${NTP_LOCK_FILE}" ] && exit 0
+
+([ "$(get_cache_var "ENABLED_DEFAULT_ACL")" = "1" ] || [ "$(get_cache_var "ENABLED_ACLS")" = "1" ]) && [ -f ${LOCK_PATH}/${CONFIG}_ready.lock ] && {
+
+	echo $$ > ${NTP_LOCK_FILE}
+
+	/etc/init.d/${CONFIG} restart >/dev/null 2>&1 &
+	logger -p notice -t network -s "${CONFIG}: restart after NTP time became valid"
+}


### PR DESCRIPTION
Fixes #1228

### Problem

Devices **without a hardware RTC** (most consumer/travel routers) boot with a wrong system clock: `sysfixtime` can only restore the mtime of the newest file under `/etc`, i.e. roughly *"when the device was last shut down"*. After a cold boot the clock is typically hours behind (measured on my device: **9 h 35 m** and **8 h**).

passwall2's only automatic restart trigger is `/etc/hotplug.d/iface/98-passwall2` (on `ifup`), which normally fires **before** NTP has corrected the time. Xray therefore starts with a wrong clock, and VMess AEAD — which embeds a timestamp the server validates within a narrow window (~±120 s) — rejects every handshake.

**Once NTP later corrects the clock, nothing restarts passwall2.** There is currently no hook under `/etc/hotplug.d/ntp/`, and `ifup` does not fire again, so the service stays broken until the user restarts it manually. Whether it happens to recover depends on whether the NTP correction lands before or after the last `ifup`, which is why the symptom looks random.

### Fix

Add `/etc/hotplug.d/ntp/30-passwall2-resync`, which restarts passwall2 once per boot when ntpd reports a valid stratum.

This mirrors what **dnsmasq already does for DNSSEC** in `/etc/hotplug.d/ntp/25-dnsmasqsec` (shipped by `dnsmasq-full`) — the same class of problem: a service whose correctness depends on the clock, running on hardware that boots with the wrong one.

The `stratum` event is a good trigger because it semantically implies *"the network is up **and** the clock has been calibrated"*, so both preconditions for a working node are satisfied at that moment.

### Implementation notes

- Follows the conventions of the existing `98-passwall2` hook: sources `utils.sh`, uses `${CONFIG}` / `${LOCK_PATH}`, gates on `ENABLED_DEFAULT_ACL` / `ENABLED_ACLS` and `${CONFIG}_ready.lock`, and logs in the same format.
- The lock file lives in `${LOCK_PATH}` (tmpfs), so it resets every boot and the restart happens **at most once per boot**.
- The lock is written **only when a restart is actually performed** — deliberately different from `25-dnsmasqsec`, which writes its flag unconditionally. This way, if a `stratum` event arrives before passwall2 is ready, a later one can still act instead of the opportunity being consumed.
- No `Makefile` change is required: the package has no custom `Package/*/install` define and uses `luci.mk`, which installs everything under `root/` automatically.

### Testing

- The **mechanism** was verified on real hardware — GL.iNet BE3600 (IPQ5332), OpenWrt 23.05-SNAPSHOT, no RTC (`hctosys: unable to open rtc device (rtc0)`), VMess node, WiFi-repeater uplink. With an equivalent `hotplug.d/ntp` hook installed, **two consecutive real cold boots recovered automatically with no manual intervention**; end-to-end proxying was confirmed after the hook fired. Without it, the device always required a manual restart.
- **Caveat, to be explicit:** that test device runs `25.3.2-r1`, which predates `utils.sh` / `get_cache_var`, so the hook I ran there was the equivalent logic written against the older conventions. **The exact script in this PR has not been executed on a device running current `main`.** What I did verify for this version: `sh -n` syntax check, and that `${LOCK_PATH}/${CONFIG}_ready.lock` resolves to `/tmp/lock/passwall2_ready.lock`, which is present on the device.
- Happy to adjust the style, the guard conditions, or the lock-file placement if you'd prefer something different.

### One open question

I did not isolate whether the clock correction *alone* would eventually let Xray recover without a full service restart — empirically it did **not** before this hook existed. If you know which cached state survives the clock step (DNS negative cache, connection pool, node health-check status, …), the fix could likely be narrowed to something less blunt than `restart`.
