### PR TITLE
fix: sanitize legacy 'disable' value in port redirect variables

### DIFF
--- a/luci-app-passwall2/root/etc/uci-defaults/luci-app-passwall2
+++ b/luci-app-passwall2/root/etc/uci-defaults/luci-app-passwall2
@@ -32,6 +32,15 @@ uci commit firewall
 
 [ ! -s "/etc/config/passwall2" ] && cp -f /usr/share/passwall2/0_default_config /etc/config/passwall2
 
+if [ -s "/etc/config/passwall2" ]; then
+	_patched=0
+	for _bad_key in $(uci -q show passwall2 | grep -E "\.(tcp|udp)_no_redir_ports='disable'" | cut -d '=' -f 1); do
+		uci -q set "$_bad_key="
+		_patched=1
+	done
+	[ "$_patched" -eq 1 ] && uci commit passwall2
+fi
+
 chmod +x /usr/share/passwall2/*.sh
 
 rm -f /tmp/luci-indexcache /tmp/luci-indexcache.*

--- a/luci-app-passwall2/root/usr/share/passwall2/iptables.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/iptables.sh
@@ -262,6 +262,9 @@ load_acl() {
 	for sid in $(jsonfilter -s "${acl_json}" -e '$.acl[*].flag'); do
 		eval local $(cat "${TMP_ACL_PATH}/${sid}/var")
 
+		[ "$tcp_no_redir_ports" = "disable" ] && tcp_no_redir_ports=""
+		[ "$udp_no_redir_ports" = "disable" ] && udp_no_redir_ports=""
+
 		[ -z "$(get_cache_var "${node}_gen_shunt_list")" ] && [ -n "${node}" ] && gen_shunt_list "${node}" shunt_list4 shunt_list6
 		[ -n "${use}" ] && local dns_redirect_port=$(get_cache_var "ACL_${use}_dns_port")
 

--- a/luci-app-passwall2/root/usr/share/passwall2/nftables.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/nftables.sh
@@ -300,6 +300,9 @@ load_acl() {
 	for sid in $(jsonfilter -s "${acl_json}" -e '$.acl[*].flag'); do
 		eval $(cat "${TMP_ACL_PATH}/${sid}/var")
 
+		[ "$tcp_no_redir_ports" = "disable" ] && tcp_no_redir_ports=""
+		[ "$udp_no_redir_ports" = "disable" ] && udp_no_redir_ports=""
+
 		[ -z "$(get_cache_var "${node}_gen_shunt_list")" ] && [ -n "${node}" ] && gen_shunt_list "${node}" shunt_list4 shunt_list6
 		[ -n "${use}" ] && local dns_redirect_port=$(get_cache_var "ACL_${use}_dns_port")
 


### PR DESCRIPTION
To fix https://github.com/Openwrt-Passwall/openwrt-passwall2/issues/1243