### PR TITLE
fix: 修复 remote_dns_detour=direct 时 blackhole 分流规则 DNS 层拦截失效

### DIFF
--- a/luci-app-passwall2/luasrc/passwall2/util_xray.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_xray.lua
@@ -1824,7 +1824,6 @@ function gen_config(var)
 					if value.domain and value.outboundTag then
 						local dns_server = nil
 						local dns_outboundTag = value.outboundTag
-						local original_outboundTag = value.outboundTag
 						if value.dns_server then
 							dns_server = api.clone(value.dns_server)
 						elseif value.outboundTag == "direct" then
@@ -1839,7 +1838,7 @@ function gen_config(var)
 								end
 							end
 						end
-						if original_outboundTag == "blackhole" then
+						if value.outboundTag == "blackhole" then
 							table.insert(dns_out_rules, {
 								action = "return",
 								rCode = 0,

--- a/luci-app-passwall2/luasrc/passwall2/util_xray.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_xray.lua
@@ -1824,6 +1824,7 @@ function gen_config(var)
 					if value.domain and value.outboundTag then
 						local dns_server = nil
 						local dns_outboundTag = value.outboundTag
+						local original_outboundTag = value.outboundTag
 						if value.dns_server then
 							dns_server = api.clone(value.dns_server)
 						elseif value.outboundTag == "direct" then
@@ -1838,7 +1839,7 @@ function gen_config(var)
 								end
 							end
 						end
-						if dns_outboundTag == "blackhole" then
+						if original_outboundTag == "blackhole" then
 							table.insert(dns_out_rules, {
 								action = "return",
 								rCode = 0,


### PR DESCRIPTION
当远程DNS出口设为直连时，dns_outboundTag 在 blackhole 判断之前被覆盖为 "direct"，导致黑洞规则被错误生成为 hijack 并创建 DNS 服务器，广告域名被转发
到远程DNS解析而非直接 return。

引入 original_outboundTag 保存原始出口动作用于 blackhole 判断，dns_outboundTag 继续用于 DNS 服务器的实际出口设置，两者职责分离。