### PR TITLE
luci: fix lease2hosts reload after pid file rename in 0e0644b

### DIFF
--- a/luci-app-passwall2/root/usr/share/passwall2/lease2hosts.sh
+++ b/luci-app-passwall2/root/usr/share/passwall2/lease2hosts.sh
@@ -3,7 +3,7 @@
 
 . /usr/share/passwall2/utils.sh
 LOCK_FILE=${LOCK_PATH}/${CONFIG}_lease2hosts.lock
-LEASE_FILE="/tmp/dhcp.leases"
+LEASE_FILE=$(config_t_get dnsmasq leasefile "/tmp/dhcp.leases")
 HOSTS_FILE="$TMP_PATH2/dhcp-hosts"
 TMP_FILE="/tmp/dhcp-hosts.tmp"
 
@@ -15,7 +15,7 @@ fi
 
 reload_dnsmasq_pids() {
 	local pidfile pid
-	find $TMP_PATH/acl -type f -name 'dnsmasq.pid' 2>/dev/null | while read pidfile; do
+	find $TMP_PATH/acl -type f -name '*_dnsmasq.pid' 2>/dev/null | while read pidfile; do
 		if [ -s "$pidfile" ]; then
 			read pid < "$pidfile"
 			if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then


### PR DESCRIPTION
Follow-up to the DHCP hostname fix from c0ea8dc (#1261, #1100). That commit makes the standalone dnsmasq load `dhcp-hosts` at startup, but the **runtime reload path is still broken** since 26.8.27:

## Bug 1: SIGHUP never reaches any dnsmasq (regression from 0e0644b)

`lease2hosts.sh` reloads instances via:

```sh
find $TMP_PATH/acl -type f -name 'dnsmasq.pid' ...
```

but 0e0644b ("luci: refactoring and fix ACL logic", 2026-08-17) renamed the pid files in `run_copy_dnsmasq`:

```sh
local dnsmasq_pid="${TMP_ACL_PATH}/${flag}_dnsmasq.pid"
```

`find -name` is an exact basename match, so on 26.8.27+/26.9.2 the pattern matches **zero** files. `dhcp-hosts` is still refreshed every 60s, but the SIGHUP lands nowhere — a newly leased hostname only resolves after the next passwall2 restart/WAN re-dial, which is exactly the residual symptom behind #1261.

Fix: match `'*_dnsmasq.pid'`. Verified this is the only pid-file layout written under `$TMP_ACL_PATH` in current main (`app.sh:738`), so no false positives.

## Bug 2: hardcoded lease file breaks persistent-leasefile setups

`LEASE_FILE="/tmp/dhcp.leases"` is hardcoded, while OpenWrt exposes `dhcp.@dnsmasq[0].leasefile` (users keeping leases on persistent storage, as raised by @Kurobac in #1100). For them `awk` reads the wrong file, the loop never writes `dhcp-hosts`, and the feature silently does nothing.

Fix: read it via the existing `config_t_get` helper with `/tmp/dhcp.leases` as fallback (same pattern used elsewhere in the codebase).

## Verification

- Syntax: `sh -n` clean
- End-to-end simulation of the fixed script against the 26.9.2 pid layout (`acl/default_dnsmasq.pid`):
  - default leasefile → hosts file updated + HUP delivered to the pid from the pid file
  - persistent leasefile via uci → same path works
  - idempotence: unchanged content (cmp) does not re-HUP
- dnsmasq behavior confirmed from upstream source: `SIGHUP → EVENT_RELOAD → cache_reload()` re-reads every `addn-hosts` file unconditionally (src/dnsmasq.c, src/cache.c), so the HUP-based design is sound once delivery is fixed
- Regression window pinned: 26.8.20 unaffected, 26.8.27/26.9.2 affected (tags checked against 0e0644b ancestry)

Fixes the residual part of #1261. Refs #1100.