### PR TITLE
Refactor proxy settings to use dialer_proxy_tag

### DIFF
--- a/luci-app-passwall2/luasrc/passwall2/util_xray.lua
+++ b/luci-app-passwall2/luasrc/passwall2/util_xray.lua
@@ -59,6 +59,7 @@ function gen_outbound(flag, node, tag, proxy_table)
 		local remarks = node.remarks
 
 		local proxy_tag = nil
+		local dialer_proxy_tag = nil
 		local fragment = nil
 		local noise = nil
 		local run_socks_instance = true
@@ -97,12 +98,7 @@ function gen_outbound(flag, node, tag, proxy_table)
 			node.stream_security = "none"
 			proxy_tag = "socks <- " .. node_id
 		else
-			if proxy_tag then
-				node.proxySettings = {
-					tag = proxy_tag,
-					transportLayer = true
-				}
-			end
+			dialer_proxy_tag = proxy_tag
 		end
 		
 		if node.type == "Xray" then
@@ -146,14 +142,13 @@ function gen_outbound(flag, node, tag, proxy_table)
 			_flag = flag,
 			_flag_proxy_tag = proxy_tag,
 			tag = tag,
-			proxySettings = node.proxySettings or nil,
 			protocol = node.protocol,
 			mux = {
 				enabled = (node.mux == "1") and true or false,
 				concurrency = (node.mux == "1" and ((node.mux_concurrency) and tonumber(node.mux_concurrency) or -1)) or nil,
 				xudpConcurrency = (node.mux == "1" and ((node.xudp_concurrency) and tonumber(node.xudp_concurrency) or 8)) or nil
 			} or nil,
-			streamSettings = (node.streamSettings or node.protocol == "vmess" or node.protocol == "vless" or node.protocol == "socks" or node.protocol == "shadowsocks" or node.protocol == "trojan" or node.protocol == "hysteria") and {
+			streamSettings = (node.streamSettings or dialer_proxy_tag or node.protocol == "vmess" or node.protocol == "vless" or node.protocol == "socks" or node.protocol == "shadowsocks" or node.protocol == "trojan" or node.protocol == "hysteria") and {
 				sockopt = {
 					mark = 255,
 					domainStrategy = node.domain_strategy or "UseIP",
@@ -164,7 +159,8 @@ function gen_outbound(flag, node, tag, proxy_table)
 						PrioritizeIPv6 = false,
 						Interleave = 1,
 						MaxConcurrentTry = 4
-					} or nil
+					} or nil,
+					dialerProxy = dialer_proxy_tag,
 				},
 				[(api.compare_versions(xray_version, "<", "26.7.11")) and "network" or "method"] = node.transport, -- Todo: Remove version check and "network"
 				security = node.stream_security,
@@ -1208,10 +1204,9 @@ function gen_config(var)
 					end
 					if preproxy_outbound then
 						outbound.tag = preproxy_outbound.tag .. " -> " .. outbound.tag
-						outbound.proxySettings = {
-							tag = preproxy_outbound.tag,
-							transportLayer = true
-						}
+						outbound.streamSettings = outbound.streamSettings or {}
+						outbound.streamSettings.sockopt = outbound.streamSettings.sockopt or {}
+						outbound.streamSettings.sockopt.dialerProxy = preproxy_outbound.tag
 						if not exist then
 							last_insert_outbound = preproxy_outbound
 						end
@@ -1259,10 +1254,9 @@ function gen_config(var)
 				if to_outbound then
 					to_outbound.tag = outbound.tag .. " -> " .. to_outbound.tag
 					if to_node.type == "Xray" then
-						to_outbound.proxySettings = {
-							tag = outbound.tag,
-							transportLayer = true
-						}
+						to_outbound.streamSettings = to_outbound.streamSettings or {}
+						to_outbound.streamSettings.sockopt = to_outbound.streamSettings.sockopt or {}
+						to_outbound.streamSettings.sockopt.dialerProxy = outbound.tag
 					end
 					table.insert(outbounds_table, to_outbound)
 					default_outTag = to_outbound.tag


### PR DESCRIPTION
To fix https://github.com/Openwrt-Passwall/openwrt-passwall2/issues/1271 :
```
errors: The feature outbound "proxySettings" has been removed and migrated to "streamSettings.sockopt.dialerProxy".
```
Considering that Xray had already deprecated `proxySettings` a few years ago, it is no longer reused here, the name `node.proxySettings`, which no longer exists in the Xray schema, as "transformation amount" (it is easy for future maintenance people to mistake it for a real field), and directly use a clear local variable: `local dialer_proxy_tag = nil`